### PR TITLE
Implement generic QR code functionality

### DIFF
--- a/app/src/androidTest/java/com/github/dedis/student20_pop/ui/OrganizerFragmentTest.java
+++ b/app/src/androidTest/java/com/github/dedis/student20_pop/ui/OrganizerFragmentTest.java
@@ -1,14 +1,19 @@
 package com.github.dedis.student20_pop.ui;
 
+import android.Manifest;
 import android.view.View;
 
+import androidx.fragment.app.Fragment;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.rule.GrantPermissionRule;
 
+import com.github.dedis.student20_pop.MainActivity;
 import com.github.dedis.student20_pop.OrganizerActivity;
 import com.github.dedis.student20_pop.R;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -26,6 +31,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType.ADD_WITNESS;
+import static com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType.CONNECT_LAO;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.not;
@@ -37,6 +44,8 @@ public class OrganizerFragmentTest {
     @Rule
     public ActivityScenarioRule<OrganizerActivity> activityScenarioRule =
             new ActivityScenarioRule<>(OrganizerActivity.class);
+
+    @Rule public final GrantPermissionRule rule = GrantPermissionRule.grant(Manifest.permission.CAMERA);
 
     @Before
     public void setUp() {
@@ -172,6 +181,21 @@ public class OrganizerFragmentTest {
     @Test
     @Ignore("TODO : Check that scanning a Witness QR code adds witness to witness list")
     public void canAddWitness() {
+        final String TEST_URL = "Test new witness";
+        onView(withId(R.id.tab_properties)).perform(click());
+        onView(withId(R.id.properties_view)).check(matches(isDisplayed()));
+        onView(withId(R.id.edit_button)).perform(click());
+        onView(withId(R.id.add_witness_button)).perform(click());
+
+        // Simulate a detected url
+        activityScenarioRule.getScenario().onActivity(a -> {
+            Fragment fragment = a.getSupportFragmentManager().findFragmentByTag(QRCodeScanningFragment.TAG);
+            Assert.assertNotNull(fragment);
+            Assert.assertTrue(fragment instanceof QRCodeScanningFragment);
+            ((QRCodeScanningFragment) fragment).onQRCodeDetected(TEST_URL, ADD_WITNESS);
+        });
+
+        //TODO 
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/dedis/student20_pop/ui/QRCodeScanningFragmentTest.java
+++ b/app/src/androidTest/java/com/github/dedis/student20_pop/ui/QRCodeScanningFragmentTest.java
@@ -21,6 +21,7 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType.CONNECT_LAO;
 
 /**
  * Class handling connect fragment tests
@@ -44,7 +45,7 @@ public class QRCodeScanningFragmentTest {
             Fragment fragment = a.getSupportFragmentManager().findFragmentByTag(QRCodeScanningFragment.TAG);
             Assert.assertNotNull(fragment);
             Assert.assertTrue(fragment instanceof QRCodeScanningFragment);
-            ((QRCodeScanningFragment) fragment).onQRCodeDetected(TEST_URL);
+            ((QRCodeScanningFragment) fragment).onQRCodeDetected(TEST_URL, CONNECT_LAO);
         });
 
         // Check everything

--- a/app/src/androidTest/java/com/github/dedis/student20_pop/ui/QRCodeScanningFragmentTest.java
+++ b/app/src/androidTest/java/com/github/dedis/student20_pop/ui/QRCodeScanningFragmentTest.java
@@ -25,7 +25,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 /**
  * Class handling connect fragment tests
  */
-public class ConnectFragmentTest {
+public class QRCodeScanningFragmentTest {
 
     private static final String TEST_URL = "Test url";
 
@@ -41,10 +41,10 @@ public class ConnectFragmentTest {
 
         // Simulate a detected url
         scenario.onActivity(a -> {
-            Fragment fragment = a.getSupportFragmentManager().findFragmentByTag(ConnectFragment.TAG);
+            Fragment fragment = a.getSupportFragmentManager().findFragmentByTag(QRCodeScanningFragment.TAG);
             Assert.assertNotNull(fragment);
-            Assert.assertTrue(fragment instanceof ConnectFragment);
-            ((ConnectFragment) fragment).onQRCodeDetected(TEST_URL);
+            Assert.assertTrue(fragment instanceof QRCodeScanningFragment);
+            ((QRCodeScanningFragment) fragment).onQRCodeDetected(TEST_URL);
         });
 
         // Check everything

--- a/app/src/main/java/com/github/dedis/student20_pop/MainActivity.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/MainActivity.java
@@ -8,7 +8,6 @@ import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.Toast;
-import android.widget.Toast;
 
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
@@ -17,10 +16,15 @@ import androidx.fragment.app.FragmentActivity;
 import com.github.dedis.student20_pop.model.Lao;
 import com.github.dedis.student20_pop.model.Person;
 import com.github.dedis.student20_pop.ui.CameraPermissionFragment;
-import com.github.dedis.student20_pop.ui.ConnectFragment;
+import com.github.dedis.student20_pop.ui.ConnectingFragment;
 import com.github.dedis.student20_pop.ui.HomeFragment;
 import com.github.dedis.student20_pop.ui.LaunchFragment;
+import com.github.dedis.student20_pop.ui.QRCodeScanningFragment;
+import com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType;
 import com.github.dedis.student20_pop.utility.network.PoPClientEndpoint;
+import com.github.dedis.student20_pop.utility.qrcode.OnCameraAllowedListener;
+import com.github.dedis.student20_pop.utility.qrcode.OnCameraNotAllowedListener;
+import com.github.dedis.student20_pop.utility.qrcode.QRCodeListener;
 import com.github.dedis.student20_pop.utility.security.PrivateInfoStorage;
 
 import java.net.URI;
@@ -30,10 +34,12 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.websocket.DeploymentException;
 
+import static com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType.CONNECT_LAO;
+
 /**
  * Activity used to display the different UIs
  **/
-public final class MainActivity extends FragmentActivity {
+public final class MainActivity extends FragmentActivity implements OnCameraNotAllowedListener, QRCodeListener, OnCameraAllowedListener {
 
     public static final String TAG = MainActivity.class.getSimpleName();
 
@@ -64,9 +70,9 @@ public final class MainActivity extends FragmentActivity {
                 break;
             case R.id.tab_connect:
                 if (ActivityCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)
-                    showFragment(new ConnectFragment(), ConnectFragment.TAG);
+                    showFragment(new QRCodeScanningFragment(CONNECT_LAO), QRCodeScanningFragment.TAG);
                 else
-                    showFragment(new CameraPermissionFragment(), CameraPermissionFragment.TAG);
+                    showFragment(new CameraPermissionFragment(CONNECT_LAO), CameraPermissionFragment.TAG);
                 break;
             case R.id.tab_launch:
                 showFragment(new LaunchFragment(), LaunchFragment.TAG);
@@ -130,5 +136,33 @@ public final class MainActivity extends FragmentActivity {
                     .addToBackStack(TAG)
                     .commit();
         }
+    }
+
+    @Override
+    public void onCameraNotAllowedListener(QRCodeScanningType qrCodeScanningType) {
+        showFragment(new CameraPermissionFragment(qrCodeScanningType), CameraPermissionFragment.TAG);
+    }
+
+    @Override
+    public void onQRCodeDetected(String url, QRCodeScanningType qrCodeScanningType) {
+        Log.i(TAG, "Received qrcode url : " + url);
+        switch (qrCodeScanningType) {
+            case ADD_ROLL_CALL:
+                //TODO
+                break;
+            case ADD_WITNESS:
+                //TODO
+                break;
+            case CONNECT_LAO:
+                showFragment(ConnectingFragment.newInstance(url), ConnectingFragment.TAG);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public void onCameraAllowedListener(QRCodeScanningType qrCodeScanningType) {
+        showFragment(new QRCodeScanningFragment(qrCodeScanningType), QRCodeScanningFragment.TAG);
     }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/OrganizerActivity.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/OrganizerActivity.java
@@ -13,20 +13,27 @@ import androidx.fragment.app.FragmentActivity;
 import com.github.dedis.student20_pop.model.Keys;
 import com.github.dedis.student20_pop.model.Lao;
 import com.github.dedis.student20_pop.ui.CameraPermissionFragment;
-import com.github.dedis.student20_pop.ui.ConnectFragment;
+import com.github.dedis.student20_pop.ui.ConnectingFragment;
 import com.github.dedis.student20_pop.ui.HomeFragment;
 import com.github.dedis.student20_pop.ui.IdentityFragment;
 import com.github.dedis.student20_pop.ui.OrganizerFragment;
-import com.github.dedis.student20_pop.utility.security.PrivateInfoStorage;
+import com.github.dedis.student20_pop.ui.QRCodeScanningFragment;
+import com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType;
+import com.github.dedis.student20_pop.utility.qrcode.OnCameraAllowedListener;
+import com.github.dedis.student20_pop.utility.qrcode.OnCameraNotAllowedListener;
+import com.github.dedis.student20_pop.utility.qrcode.QRCodeListener;
 import com.github.dedis.student20_pop.utility.ui.OnAddWitnessListener;
 import com.github.dedis.student20_pop.utility.ui.OnEventTypeSelectedListener;
 
 import java.util.Date;
 
+import static com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType.ADD_WITNESS;
+
 /**
  * Activity used to display the different UIs for organizers
  **/
-public class OrganizerActivity extends FragmentActivity implements OnEventTypeSelectedListener, OnAddWitnessListener {
+public class OrganizerActivity extends FragmentActivity implements OnEventTypeSelectedListener, OnAddWitnessListener,
+        OnCameraNotAllowedListener, QRCodeListener, OnCameraAllowedListener {
 
     public static final String TAG = OrganizerActivity.class.getSimpleName();
     public static final String PRIVATE_KEY_TAG = "PRIVATE_KEY";
@@ -118,10 +125,38 @@ public class OrganizerActivity extends FragmentActivity implements OnEventTypeSe
     @Override
     public void onAddWitnessListener() {
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
-            showFragment(new ConnectFragment(R.id.fragment_container_organizer), ConnectFragment.TAG);
+            showFragment(new QRCodeScanningFragment(ADD_WITNESS), QRCodeScanningFragment.TAG);
         } else {
-            showFragment(new CameraPermissionFragment(R.id.fragment_container_organizer), CameraPermissionFragment.TAG);
+            showFragment(new CameraPermissionFragment(ADD_WITNESS), CameraPermissionFragment.TAG);
         }
         // TODO : Get witness id from the QR code, add witness to witness list and send info to backend
+    }
+
+    @Override
+    public void onCameraNotAllowedListener(QRCodeScanningType qrCodeScanningType) {
+        showFragment(new CameraPermissionFragment(qrCodeScanningType), CameraPermissionFragment.TAG);
+    }
+
+    @Override
+    public void onQRCodeDetected(String url, QRCodeScanningType qrCodeScanningType) {
+        Log.i(TAG, "Received qrcode url : " + url);
+        switch (qrCodeScanningType) {
+            case ADD_ROLL_CALL:
+                //TODO
+                break;
+            case ADD_WITNESS:
+                //TODO
+                break;
+            case CONNECT_LAO:
+                showFragment(ConnectingFragment.newInstance(url), ConnectingFragment.TAG);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public void onCameraAllowedListener(QRCodeScanningType qrCodeScanningType) {
+        showFragment(new QRCodeScanningFragment(qrCodeScanningType), QRCodeScanningFragment.TAG);
     }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/OrganizerActivity.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/OrganizerActivity.java
@@ -146,6 +146,7 @@ public class OrganizerActivity extends FragmentActivity implements OnEventTypeSe
                 break;
             case ADD_WITNESS:
                 //TODO
+                Log.d("DEBUG", "URL Received : " + url);
                 break;
             case CONNECT_LAO:
                 showFragment(ConnectingFragment.newInstance(url), ConnectingFragment.TAG);

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/CameraPermissionFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/CameraPermissionFragment.java
@@ -1,6 +1,7 @@
 package com.github.dedis.student20_pop.ui;
 
 import android.Manifest;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -13,24 +14,33 @@ import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 
 import com.github.dedis.student20_pop.R;
+import com.github.dedis.student20_pop.utility.qrcode.OnCameraAllowedListener;
 
 /**
  * Fragment handling permission granting for the camera
  */
 public final class CameraPermissionFragment extends Fragment implements View.OnClickListener {
 
-    public static final String TAG = ConnectFragment.class.getSimpleName();
-
+    public static final String TAG = CameraPermissionFragment.class.getSimpleName();
     private static final int HANDLE_CAMERA_PERM = 2;
-    private int container;
+    private final QRCodeScanningFragment.QRCodeScanningType qrCodeScanningType;
 
-    public CameraPermissionFragment(){
-        this(R.id.fragment_container_main);
+    private OnCameraAllowedListener onCameraAllowedListener;
+
+    public CameraPermissionFragment(QRCodeScanningFragment.QRCodeScanningType qrCodeScanningType){
+        super();
+        this.qrCodeScanningType = qrCodeScanningType;
     }
 
-    public CameraPermissionFragment(int container){
-        super();
-        this.container = container;
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        try {
+            onCameraAllowedListener = (OnCameraAllowedListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(context.toString() + " must implement listeners");
+        }
     }
 
     @Override
@@ -39,18 +49,10 @@ public final class CameraPermissionFragment extends Fragment implements View.OnC
         //set button click listener
         view.findViewById(R.id.allow_camera_button).setOnClickListener(this);
 
-        // Check for the camera permission, if is is granted, switch to ConnectFragment
+        // Check for the camera permission, if is is granted, switch to QRCodeScanningFragment
         if (ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)
-            switchToConnectFragment();
-
+            onCameraAllowedListener.onCameraAllowedListener(qrCodeScanningType);
         return view;
-    }
-
-    private void switchToConnectFragment() {
-        requireFragmentManager()
-                .beginTransaction()
-                .replace(container, new ConnectFragment(), ConnectFragment.TAG)
-                .commit();
     }
 
     @Override
@@ -60,23 +62,23 @@ public final class CameraPermissionFragment extends Fragment implements View.OnC
         if (requestCode == HANDLE_CAMERA_PERM &&
                 grantResults.length != 0 &&
                 grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            // we have permission, so we switch to ConnectFragment
-            switchToConnectFragment();
+            // we have permission, so we switch to QRCodeScanningFragment
+            onCameraAllowedListener.onCameraAllowedListener(qrCodeScanningType);
         }
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        // If the permission was granted while the app was paused, switch to ConnectFragment
+        // If the permission was granted while the app was paused, switch to QRCodeScanningFragment
 
         if (ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)
-            switchToConnectFragment();
+            onCameraAllowedListener.onCameraAllowedListener(qrCodeScanningType);
     }
 
     @Override
     public void onClick(View v) {
-        if(v.getId() == R.id.allow_camera_button) {
+        if (v.getId() == R.id.allow_camera_button) {
             requestPermissions(new String[]{Manifest.permission.CAMERA}, HANDLE_CAMERA_PERM);
         }
     }

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/CameraPermissionFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/CameraPermissionFragment.java
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 
+import com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType;
 import com.github.dedis.student20_pop.R;
 import com.github.dedis.student20_pop.utility.qrcode.OnCameraAllowedListener;
 
@@ -23,11 +24,11 @@ public final class CameraPermissionFragment extends Fragment implements View.OnC
 
     public static final String TAG = CameraPermissionFragment.class.getSimpleName();
     private static final int HANDLE_CAMERA_PERM = 2;
-    private final QRCodeScanningFragment.QRCodeScanningType qrCodeScanningType;
+    private final QRCodeScanningType qrCodeScanningType;
 
     private OnCameraAllowedListener onCameraAllowedListener;
 
-    public CameraPermissionFragment(QRCodeScanningFragment.QRCodeScanningType qrCodeScanningType){
+    public CameraPermissionFragment(QRCodeScanningType qrCodeScanningType){
         super();
         this.qrCodeScanningType = qrCodeScanningType;
     }

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/ConnectingFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/ConnectingFragment.java
@@ -4,9 +4,11 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.TextView;
 
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 import com.github.dedis.student20_pop.R;
 
@@ -29,7 +31,7 @@ public final class ConnectingFragment extends Fragment {
      * @param url to connect to
      * @return A new instance of fragment ConnectingFragment.
      */
-    public static ConnectingFragment newInstance(String url) {
+    public static ConnectingFragment   newInstance(String url) {
         ConnectingFragment fragment = new ConnectingFragment();
         Bundle args = new Bundle();
         args.putString(URL_EXTRA, url);
@@ -52,6 +54,12 @@ public final class ConnectingFragment extends Fragment {
 
         TextView url_view = view.findViewById(R.id.connecting_url);
         url_view.setText(url);
+
+        final FragmentManager fragmentManager = (getActivity()).getSupportFragmentManager();
+        Button cancelButton = view.findViewById(R.id.button_cancel_connecting);
+        cancelButton.setOnClickListener(v -> {
+            fragmentManager.popBackStackImmediate();
+        });
 
         return view;
     }

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/ConnectingFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/ConnectingFragment.java
@@ -17,7 +17,7 @@ import com.github.dedis.student20_pop.R;
  */
 public final class ConnectingFragment extends Fragment {
 
-    public static final String TAG = ConnectFragment.class.getSimpleName();
+    public static final String TAG = ConnectingFragment.class.getSimpleName();
     private static final String URL_EXTRA = "url";
 
     private String url;

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/QRCodeScanningFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/QRCodeScanningFragment.java
@@ -158,7 +158,7 @@ public final class QRCodeScanningFragment extends Fragment implements QRCodeList
     }
 
     @Override
-    public void onQRCodeDetected(String url, QRCodeScanningType qrCodeScanningType) {
-        qrCodeListener.onQRCodeDetected(url, qrCodeScanningType);
+    public void onQRCodeDetected(String data, QRCodeScanningType qrCodeScanningType) {
+        qrCodeListener.onQRCodeDetected(data, qrCodeScanningType);
     }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/QRCodeScanningFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/QRCodeScanningFragment.java
@@ -1,6 +1,7 @@
 package com.github.dedis.student20_pop.ui;
 
 import android.Manifest;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.hardware.Camera;
 import android.os.Bundle;
@@ -16,6 +17,7 @@ import androidx.fragment.app.Fragment;
 
 import com.github.dedis.student20_pop.R;
 import com.github.dedis.student20_pop.utility.qrcode.CameraPreview;
+import com.github.dedis.student20_pop.utility.qrcode.OnCameraNotAllowedListener;
 import com.github.dedis.student20_pop.utility.qrcode.QRCodeListener;
 import com.github.dedis.student20_pop.utility.qrcode.QRFocusingProcessor;
 import com.google.android.gms.common.ConnectionResult;
@@ -26,28 +28,60 @@ import com.google.android.gms.vision.barcode.BarcodeDetector;
 
 import java.io.IOException;
 
+import static com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType.CONNECT_LAO;
+
 /**
  * Fragment used to display the Connect UI
  **/
-public final class ConnectFragment extends Fragment implements QRCodeListener {
+public final class QRCodeScanningFragment extends Fragment implements QRCodeListener {
 
-    public static final String TAG = ConnectFragment.class.getSimpleName();
-
+    public static final String TAG = QRCodeScanningFragment.class.getSimpleName();
     private static final int HANDLE_GMS = 9001;
-    private static final String CONTAINER = "container";
-
 
     private CameraSource camera;
     private CameraPreview preview;
-    private int container;
+    private OnCameraNotAllowedListener onCameraNotAllowedListener;
+    private QRCodeListener qrCodeListener;
+    private QRCodeScanningType qrCodeScanningType;
 
-    public ConnectFragment() {
-        this(R.id.fragment_container_main);
+    /**
+     * Enum representing QR code functionality
+     * If QRCodeScanningFragment is launched to add a witness
+     * or connect to a lao or to add an attendee to a roll call event
+     */
+    public enum QRCodeScanningType {
+        ADD_ROLL_CALL,
+        ADD_WITNESS,
+        CONNECT_LAO
+
     }
 
-    public ConnectFragment(int resource){
+    /**
+     * Default Fragment constructor
+     */
+    public QRCodeScanningFragment() {
+        new QRCodeScanningFragment(CONNECT_LAO);
+    }
+
+    /**
+     * Fragment constructor
+     *
+     * @param qrCodeScanningType tell what should be done with QR code information
+     */
+    public QRCodeScanningFragment(QRCodeScanningType qrCodeScanningType) {
         super();
-        container = resource;
+        this.qrCodeScanningType = qrCodeScanningType;
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        try {
+            onCameraNotAllowedListener = (OnCameraNotAllowedListener) context;
+            qrCodeListener = (QRCodeListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(context.toString() + " must implement listeners");
+        }
     }
 
     @Override
@@ -60,7 +94,7 @@ public final class ConnectFragment extends Fragment implements QRCodeListener {
         if (ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)
             camera = createCamera();
         else
-            switchToCameraPermissionFragment();
+            onCameraNotAllowedListener.onCameraNotAllowedListener(qrCodeScanningType);
 
         return view;
     }
@@ -70,7 +104,7 @@ public final class ConnectFragment extends Fragment implements QRCodeListener {
                 .setBarcodeFormats(Barcode.QR_CODE)
                 .build();
 
-        qrDetector.setProcessor(new QRFocusingProcessor(qrDetector, this));
+        qrDetector.setProcessor(new QRFocusingProcessor(qrDetector, this, qrCodeScanningType));
 
         return new CameraSource.Builder(requireContext(), qrDetector)
                 .setFacing(CameraSource.CAMERA_FACING_BACK)
@@ -79,14 +113,6 @@ public final class ConnectFragment extends Fragment implements QRCodeListener {
                 .setRequestedFps(15.0f)
                 .setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)
                 .build();
-    }
-
-
-    private void switchToCameraPermissionFragment() {
-        requireFragmentManager()
-                .beginTransaction()
-                .replace(R.id.fragment_container_main, new CameraPermissionFragment(), CameraPermissionFragment.TAG)
-                .commit();
     }
 
     private void startCamera() throws SecurityException {
@@ -114,29 +140,25 @@ public final class ConnectFragment extends Fragment implements QRCodeListener {
         if (ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)
             startCamera();
         else
-            switchToCameraPermissionFragment();
+            onCameraNotAllowedListener.onCameraNotAllowedListener(qrCodeScanningType);
     }
 
     @Override
     public void onPause() {
         super.onPause();
-        if(preview != null)
+        if (preview != null)
             preview.stop();
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-        if(preview != null)
+        if (preview != null)
             preview.release();
     }
 
     @Override
-    public void onQRCodeDetected(String url) {
-        Log.i(TAG, "Received qrcode url : " + url);
-        requireFragmentManager()
-                .beginTransaction()
-                .replace(container, ConnectingFragment.newInstance(url), ConnectingFragment.TAG)
-                .addToBackStack(TAG).commit();
+    public void onQRCodeDetected(String url, QRCodeScanningType qrCodeScanningType) {
+        qrCodeListener.onQRCodeDetected(url, qrCodeScanningType);
     }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/OnCameraAllowedListener.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/OnCameraAllowedListener.java
@@ -1,0 +1,11 @@
+package com.github.dedis.student20_pop.utility.qrcode;
+
+import com.github.dedis.student20_pop.ui.QRCodeScanningFragment;
+
+/**
+ * Use this listener to switch to fragment that needed
+ * camera permission before
+ */
+public interface OnCameraAllowedListener {
+    void onCameraAllowedListener(QRCodeScanningFragment.QRCodeScanningType qrCodeScanningType);
+}

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/OnCameraNotAllowedListener.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/OnCameraNotAllowedListener.java
@@ -1,0 +1,12 @@
+package com.github.dedis.student20_pop.utility.qrcode;
+
+import com.github.dedis.student20_pop.ui.QRCodeScanningFragment;
+
+/**
+ * Use this listener to tell activity to switch to
+ * CameraPermissionFragment when current fragment needs
+ * camera permission
+ */
+public interface OnCameraNotAllowedListener {
+    void onCameraNotAllowedListener(QRCodeScanningFragment.QRCodeScanningType qrCodeScanningType);
+}

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/QRCodeListener.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/QRCodeListener.java
@@ -1,9 +1,11 @@
 package com.github.dedis.student20_pop.utility.qrcode;
 
+import com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType;
+
 /**
  * A listener that will receive detected url of a QR code
  */
 public interface QRCodeListener {
 
-    void onQRCodeDetected(String url);
+    void onQRCodeDetected(String url, QRCodeScanningType qrCodeScanningType);
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/QRCodeListener.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/QRCodeListener.java
@@ -7,5 +7,5 @@ import com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningTy
  */
 public interface QRCodeListener {
 
-    void onQRCodeDetected(String url, QRCodeScanningType qrCodeScanningType);
+    void onQRCodeDetected(String data, QRCodeScanningType qrCodeScanningType);
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/QRFocusingProcessor.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/QRFocusingProcessor.java
@@ -2,6 +2,7 @@ package com.github.dedis.student20_pop.utility.qrcode;
 
 import android.util.SparseArray;
 
+import com.github.dedis.student20_pop.ui.QRCodeScanningFragment.QRCodeScanningType;
 import com.google.android.gms.vision.Detector;
 import com.google.android.gms.vision.FocusingProcessor;
 import com.google.android.gms.vision.Tracker;
@@ -15,8 +16,8 @@ import com.google.android.gms.vision.barcode.BarcodeDetector;
  */
 public class QRFocusingProcessor extends FocusingProcessor<Barcode> {
 
-    public QRFocusingProcessor(BarcodeDetector detector, QRCodeListener listener) {
-        super(detector, new BarcodeTracker(listener));
+    public QRFocusingProcessor(BarcodeDetector detector, QRCodeListener listener, QRCodeScanningType qrCodeScanningType) {
+        super(detector, new BarcodeTracker(listener, qrCodeScanningType));
     }
 
     @Override
@@ -53,15 +54,17 @@ public class QRFocusingProcessor extends FocusingProcessor<Barcode> {
     private static class BarcodeTracker extends Tracker<Barcode> {
 
         private final QRCodeListener listener;
+        private final QRCodeScanningType qrCodeScanningType;
 
-        public BarcodeTracker(QRCodeListener listener) {
+        public BarcodeTracker(QRCodeListener listener, QRCodeScanningType qrCodeScanningType) {
             this.listener = listener;
+            this.qrCodeScanningType = qrCodeScanningType;
         }
 
         @Override
         public void onNewItem(int id, Barcode barcode) {
             if(barcode.valueFormat == Barcode.URL)
-                listener.onQRCodeDetected(barcode.url.url);
+                listener.onQRCodeDetected(barcode.url.url, qrCodeScanningType);
         }
     }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/QRFocusingProcessor.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/qrcode/QRFocusingProcessor.java
@@ -11,7 +11,7 @@ import com.google.android.gms.vision.barcode.BarcodeDetector;
 
 /**
  * A Barcode processor.
- *
+ * <p>
  * This class handles the detection of barcodes and chooses the most centered to be decoded.
  */
 public class QRFocusingProcessor extends FocusingProcessor<Barcode> {
@@ -24,12 +24,12 @@ public class QRFocusingProcessor extends FocusingProcessor<Barcode> {
     public int selectFocus(Detector.Detections<Barcode> detections) {
         //Find most centered qrcode
         SparseArray<Barcode> barcodes = detections.getDetectedItems();
-        double centerX = detections.getFrameMetadata().getWidth()/2d;
-        double centerY = detections.getFrameMetadata().getHeight()/2d;
+        double centerX = detections.getFrameMetadata().getWidth() / 2d;
+        double centerY = detections.getFrameMetadata().getHeight() / 2d;
         double minSquaredDistance = Double.MAX_VALUE;
         int id = -1;
 
-        for(int i = 0; i < barcodes.size(); i++) {
+        for (int i = 0; i < barcodes.size(); i++) {
             int key = barcodes.keyAt(i);
             Barcode curBarcode = barcodes.get(key);
 
@@ -37,7 +37,7 @@ public class QRFocusingProcessor extends FocusingProcessor<Barcode> {
             double dy = centerY - curBarcode.getBoundingBox().centerY();
             double squaredDist = dx * dx + dy * dy;
 
-            if(squaredDist < minSquaredDistance) {
+            if (squaredDist < minSquaredDistance) {
                 minSquaredDistance = squaredDist;
                 id = key;
             }
@@ -48,7 +48,7 @@ public class QRFocusingProcessor extends FocusingProcessor<Barcode> {
 
     /**
      * Tracker for barcodes
-     *
+     * <p>
      * Handles new barcode detection and notify the listener
      */
     private static class BarcodeTracker extends Tracker<Barcode> {
@@ -63,7 +63,9 @@ public class QRFocusingProcessor extends FocusingProcessor<Barcode> {
 
         @Override
         public void onNewItem(int id, Barcode barcode) {
-            if(barcode.valueFormat == Barcode.URL)
+            //TODO : In some particular usage, we don't want to scan an URL but text
+            // or other type of data
+            if (barcode.valueFormat == Barcode.URL)
                 listener.onQRCodeDetected(barcode.url.url, qrCodeScanningType);
         }
     }

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/ui/AttendeeExpandableListViewEventAdapter.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/ui/AttendeeExpandableListViewEventAdapter.java
@@ -253,6 +253,4 @@ public class AttendeeExpandableListViewEventAdapter extends BaseExpandableListAd
             return Long.compare(event1.getTime(), event2.getTime());
         }
     }
-
-
 }

--- a/app/src/main/res/layout/fragment_connecting.xml
+++ b/app/src/main/res/layout/fragment_connecting.xml
@@ -37,6 +37,27 @@
             android:gravity="center"
             android:textSize="@dimen/size_title"
             android:textStyle="bold" />
+
+        <RelativeLayout
+            android:id="@+id/loadingPanel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center" >
+
+            <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                />
+        </RelativeLayout>
+
     </LinearLayout>
 
+    <Button
+        android:id="@+id/button_cancel_connecting"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/button_cancel"
+        android:layout_gravity="bottom|right"
+        />
 </FrameLayout>


### PR DESCRIPTION
The goal of this PR is to make the QR code scanning fragment generic, that way, the same fragment can be use to different applications :
- [ ] During a Roll-call event creation, attendees should show a QR code that the organizer can scan  (Not implemented yet)
- [x] To connect to a backend/LAO, need to scan organizer's QR code
- [x] To add witness

I also add 2 UI improvements in the Connecting Fragment : 

- [x] Add Cancel button when user is in "connecting . . ." state
- [x] Add Loading animation when in connecting state