### PR TITLE
Transform method 'message' to 'broadcast'

### DIFF
--- a/query/method/broadcast.json
+++ b/query/method/broadcast.json
@@ -7,7 +7,7 @@
 	"properties": {
 		"method": { 
 			"description": "[String] operation to be performed by the query",
-			"const": "message" 
+			"const": "broadcast" 
 		},
 		"params": {
 			"type": "object",


### PR DESCRIPTION
It's a one word change, but I think it is important to change it for clarity, for us, and for future teams (and at least @romain46 agrees with me, as per his message on slack).
Message is a very generic word which caused it to be used for too many different situations. I already intended to change the method name when I started working on the proto-specs as can be seen that the file was already named broadcast.json (and as per a comment on the gdoc), but it got overlooked as the specs filled up. 

Concretely, I suggest that in this project, message is only used to talk about the middle layer of json-rpc. The whole json thing is a "request", the method names should be a verb (and while _to message_ can be a verb, it's an unusual one), message is then one of the json-key, and it is tolerated as the object property of dataWitnessMessage, because the interpretation is that Witness is the verb (not the name) and Message refers to this middle-layer which is being certified.