### PR TITLE
Fix subscribe to LAO after QR scanning

### DIFF
--- a/answer/scanQRAck.json
+++ b/answer/scanQRAck.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "http://json-schema.org/draft/2019-09/schema#",
+	"$id": "https://github.com/dedis/student20_pop/tree/proto-specs/answer/scanQRAck.json",
+	"title": "Match a custom JsonRpc 2.0 message answer",
+	"description": "Match a scan QR acknowledgement",
+	"type": "object",
+
+	"properties": {
+		"jsonrpc": { "description": "[String] JsonRpc version", "const": "2.0", "$comment": "should always be \"2.0\"" },
+		"address": { "description": "[String] address of server", "const": "2.0", "$comment": "Organizer's back end server address" },
+		"channel_id": { "description": "[String] channel id", "const": "2.0", "$comment": "Channel id to be subscribed to" },
+		"id": {
+			"oneOf": [
+				{ "type": "integer" },
+				{ "type": "null" }
+			],
+			"$comment": "The id match the request id. If there was an error in detecting the id, it must be null"
+		      }
+	},
+	"additionalProperties": false,
+	"allOf": [
+		{ "required": ["jsonrpc", "address", "channel_id", "id"] }
+	],
+	"$comment": "Note: required fields: (\"jsonrpc\" \\and \"address\" \\and \"channel_id\" \\and \"id\")"
+}

--- a/query/method/message/data/dataCloseRollCall.json
+++ b/query/method/message/data/dataCloseRollCall.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256('roll_call'||lao_id||creation||name)"
+			"$comment": "Hash : SHA256('R'||lao_id||creation||name)"
 		},
 		"start": { "description": "[Timestamp] start time", "type": "integer", "minimum": 0 },
 		"end": { "description": "[Timestamp] end time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCloseRollCall.json
+++ b/query/method/message/data/dataCloseRollCall.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft/2019-09/schema#",
+	"$id": "https://github.com/dedis/student20_pop/tree/proto-specs/query/method/message/data/dataCloseRollCall.json",
+	"description": "Match a close roll-call query",
+	"type": "object",
+
+	"properties": {
+		"object": { "const": "roll_call" },
+		"action": { "const": "close" },
+		"id": {
+			"type": "string",
+			"contentEncoding": "base64",
+			"$comment": "Hash : SHA256('roll_call'||lao_id||creation||name)"
+		},
+		"start": { "description": "[Timestamp] start time", "type": "integer", "minimum": 0 },
+		"end": { "description": "[Timestamp] end time", "type": "integer", "minimum": 0 },
+		"attendees": {
+			"description": "[Array[Base64String]] list of public keys of attendees",
+			"type": "array",
+			"uniqueItems": true,
+			"items": { "type": "string", "contentEncoding": "base64" }
+		}
+	},
+	"additionalProperties": false,
+	"required": ["object", "action", "id", "start", "end", "attendees"],
+	"note": [
+
+	]
+}

--- a/query/method/message/data/dataCloseRollCall.json
+++ b/query/method/message/data/dataCloseRollCall.json
@@ -24,6 +24,13 @@
 	"additionalProperties": false,
 	"required": ["object", "action", "id", "start", "end", "attendees"],
 	"note": [
+		"When the organizer scanned all the public keys of the attendees, it closes the event",
+		"and broadcast attendees public keys. The start time corresponds to the time of openening",
+		"of the event. Usually, the event can only be closed once.",
+		"In some special case, the event may be reopened (e.g. the organizer forgot to scan the key",
+		"of an attendee, so we reopen 2 minutes later). In this case, we can close the event a",
+		"second (or more) time. The start time then corresponds to the time of the reopening,",
+		"not the original opening time."
 
 	]
 }

--- a/query/method/message/data/dataCreateMeeting.json
+++ b/query/method/message/data/dataCreateMeeting.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(lao_id||creation||name)"
+			"$comment": "Hash : SHA256('M'||lao_id||creation||name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCreateRollCall.json
+++ b/query/method/message/data/dataCreateRollCall.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256('roll_call'||lao_id||creation||name)"
+			"$comment": "Hash : SHA256('R'||lao_id||creation||name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCreateRollCall.json
+++ b/query/method/message/data/dataCreateRollCall.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "http://json-schema.org/draft/2019-09/schema#",
+	"$id": "https://github.com/dedis/student20_pop/tree/proto-specs/query/method/message/data/dataCreateRollCall.json",
+	"description": "Match a create roll-call query",
+	"type": "object",
+
+	"properties": {
+		"object": { "const": "roll_call" },
+		"action": { "const": "create" },
+		"id": {
+			"type": "string",
+			"contentEncoding": "base64",
+			"$comment": "Hash : SHA256('roll_call'||lao_id||creation||name)"
+		},
+		"name": { "type": "string" },
+		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },
+		"start": { "description": "[Timestamp] start time", "type": "integer", "minimum": 0 },
+		"scheduled": { "description": "[Timestamp] scheduled time", "type": "integer", "minimum": 0 },
+		"location": {
+			"description": "[String] location of the roll-call",
+			"type": "string"
+		},
+		"roll_call_description": {
+			"description":"An optional description of the meeting",
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": ["object", "action", "id", "name", "creation", "location"],
+	"oneOf": [
+		{"required": ["start"] },
+		{"required": ["scheduled"] }
+	],
+	"note": [
+
+	]
+}

--- a/query/method/message/data/dataOpenRollCall.json
+++ b/query/method/message/data/dataOpenRollCall.json
@@ -25,6 +25,6 @@
 		"If the roll-call was started in future mode (see create roll-call), it can be opened using",
 		"the open roll-call query. If it was closed, but it need to be reopened later (e.g. the ",
 		"organizer forgot to scan the public key of one attendee), then it can reopen it by using",
-		"the open query."
+		"the open query. In this case, the action should be set to reopen."
 	]
 }

--- a/query/method/message/data/dataOpenRollCall.json
+++ b/query/method/message/data/dataOpenRollCall.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "http://json-schema.org/draft/2019-09/schema#",
+	"$id": "https://github.com/dedis/student20_pop/tree/proto-specs/query/method/message/data/dataOpenRollCall.json",
+	"description": "Match a open roll-call query",
+	"type": "object",
+
+	"properties": {
+		"object": { "const": "roll_call" },
+		"action": { "const": "open" },
+		"id": {
+			"type": "string",
+			"contentEncoding": "base64",
+			"$comment": "Hash : SHA256('roll_call'||lao_id||creation||name)"
+		},
+		"start": { "description": "[Timestamp] start time", "type": "integer", "minimum": 0 }
+	},
+	"additionalProperties": false,
+	"required": ["object", "action", "id", "start"],
+	"note": [
+
+	]
+}

--- a/query/method/message/data/dataOpenRollCall.json
+++ b/query/method/message/data/dataOpenRollCall.json
@@ -6,7 +6,7 @@
 
 	"properties": {
 		"object": { "const": "roll_call" },
-		"action": { "const": "open" },
+		"action": { "enum": ["open", "reopen"] },
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",

--- a/query/method/message/data/dataOpenRollCall.json
+++ b/query/method/message/data/dataOpenRollCall.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256('roll_call'||lao_id||creation||name)"
+			"$comment": "Hash : SHA256('R'||lao_id||creation||name)"
 		},
 		"start": {
 			"description": "[Timestamp] start time",

--- a/query/method/message/data/dataStateMeeting.json
+++ b/query/method/message/data/dataStateMeeting.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(lao_id||creation||name)"
+			"$comment": "Hash : SHA256('M'||lao_id||creation||name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },


### PR DESCRIPTION
## Problem
During the Roll-Call the organizer has to scan the QR code of the soon to be attendees. Once the QR code has been scanned, the soon to be attendee has no way to know the channel's id he wants to subscribe to, nor the back end's server address to connect to.

![schema](https://user-images.githubusercontent.com/36727645/103096936-effc4400-4605-11eb-9580-7577afdefb55.png)

## Solution
 The following image shows in black the existing connection and in orange the needed connection. We suggest that the organizer's front end sends through a new connection, shown in green, the information the attendee needs to send a subscribe request over the orange connection (and eventually to open it in case it did not existed before). 

The message the organizer front end sends through that socket the message defined in `answer/scanQRAck.json`. This message contains the LAO channel's id, server's address, and the standard JsonRPC fields (jsonrpc and id). The websocket should be closed by the attendee after receiving this message.

Of course for this solution to be possible, the attendee has to provide, in his QR, his IP address and port to open the green connection.

This is just a quick fix and is meant to be improved and worked on in the future. In order to implement the Roll-Call as soon as possible, we need a quick solution.