### PR TITLE
Specify that hashes are made out of base64 encoding

### DIFF
--- a/query/method/message/README.md
+++ b/query/method/message/README.md
@@ -30,3 +30,6 @@ As you can see, the data field is base64 encoded. This derives from the necessit
 
 As a consequence, we decide to encode the sender's preferred representation (any valid representation) in base64, and then use that representation as input to our hash or sign function. A nice side effect of this design is that the message object signature verification is entirely independent from the structure of the data field itself: no matter what message you send, the verification will always work in the same way (compare this to signing the data field-by-field!).
 Once the data field is unencoded and parsed, the receiving peer can simply validate it and process it at the application level.
+
+## Hashes
+Hashes are made on arrays of base64 encoded strings which look like that ["Base64{Foo}", "Base64{Bar}"]. This is necessary to avoid some issues with inner "

--- a/query/method/message/README.md
+++ b/query/method/message/README.md
@@ -13,20 +13,24 @@ The message data specific to the operation is encapsulated in the data field, wh
 Origin: sender field
 Authenticity: signature and witness_signatures fields
 Uniqueness: message_id field
+```json
 {
  "data": base64({}),  /* base64 representation of an object */
  "sender": "0x123a", /* Public key of sender */
  "signature": "0x123a", /* Signature by sender over "data" */
- "message_id": "0x123a", /* hash(data||signature) */
- "witness_signatures": [],/* Signature by witnesses (sender||data) */
+ "message_id": "0x123a", /* Hash : SHA256(Array of: Base64Data, Base64Signature) */
+ "witness_signatures": [], /* Signature by witnesses (sender||data) */
 }
+```
 
 The witness_signatures field will be empty when the message is first sent by the sender. It will subsequently be filled by the server, as it receives signatures by witnesses (asynchronously). When a client receives past messages, the witness signatures will be included. 
 
 As you can see, the data field is base64 encoded. This derives from the necessity to hash and sign the field. An object cannot be signed, but one could imagine signing its JSON representation. However, a study of the JSON format will reveal that there's no "canonicalized", unique binary representation of JSON. That is, different systems may represent the same JSON object in different ways. The two following structures are identical JSON objects but have very different binary representations (field order, whitespace, newlines, unicode, etc.):
 
+```json
 { "text": "message", "temp": "15\u00f8C" }
 {"temp":"15°C","text":"message"}
+```
 
 As a consequence, we decide to encode the sender's preferred representation (any valid representation) in base64, and then use that representation as input to our hash or sign function. A nice side effect of this design is that the message object signature verification is entirely independent from the structure of the data field itself: no matter what message you send, the verification will always work in the same way (compare this to signing the data field-by-field!).
 Once the data field is unencoded and parsed, the receiving peer can simply validate it and process it at the application level.

--- a/query/method/message/data/README.md
+++ b/query/method/message/data/README.md
@@ -1,0 +1,9 @@
+# student20_pop: proto-spec branch
+Proof-of-personhood, fall 2020: Protocol specification
+
+_There is a general README at the top-level of the branch._
+
+# High-level (data) communication
+
+## Hashes
+Hashes are made on arrays of base64 encoded strings which look like that ["Base64{Foo}", "Base64{Bar}"]. This is necessary to avoid some issues with inner " (escaping them with \" was an explored alternative which still had issues)

--- a/query/method/message/data/README.md
+++ b/query/method/message/data/README.md
@@ -6,8 +6,6 @@ _There is a general README at the top-level of the branch._
 # High-level (data) communication
 
 ## Hashes
-<<<<<<< HEAD
+
 Hashes are made on arrays of base64 encoded strings which look like that ["Base64{Foo}", "Base64{Bar}"]. This is necessary to avoid some issues with inner " (escaping them with \" was an explored alternative which still had issues)
-=======
-Hashes are made on arrays of base64 encoded strings which look like that ["Base64{Foo}", "Base64{Bar}"]. This is necessary to avoid some issues with inner "
->>>>>>> a63d8f551b5193918ba649fc29addea61f13505f
+

--- a/query/method/message/data/data.json
+++ b/query/method/message/data/data.json
@@ -10,7 +10,7 @@
 		"id": { 
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(Array of Base64Organizer, Base64Creation, Base64Name)"
+			"$comment": "Hash : SHA256(Array of: Base64Organizer, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/data.json
+++ b/query/method/message/data/data.json
@@ -10,7 +10,7 @@
 		"id": { 
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(organizer||creation||name)"
+			"$comment": "Hash : SHA256(Array of Base64Organizer, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCloseRollCall.json
+++ b/query/method/message/data/dataCloseRollCall.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(Array of Base64'R', Base64LAO_id, Base64Creation, Base64Name)"
+			"$comment": "Hash : SHA256(Array of: Base64Encode('R'), Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"start": { "description": "[Timestamp] start time", "type": "integer", "minimum": 0 },
 		"end": { "description": "[Timestamp] end time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCloseRollCall.json
+++ b/query/method/message/data/dataCloseRollCall.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256('R'||lao_id||creation||name)"
+			"$comment": "Hash : SHA256(Array of Base64'R', Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"start": { "description": "[Timestamp] start time", "type": "integer", "minimum": 0 },
 		"end": { "description": "[Timestamp] end time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCreateLao.json
+++ b/query/method/message/data/dataCreateLao.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(Array of Base64Organizer, Base64Creation, Base64Name)"
+			"$comment": "Hash : SHA256(Array of: Base64Organizer, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCreateLao.json
+++ b/query/method/message/data/dataCreateLao.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(organizer||creation||name)"
+			"$comment": "Hash : SHA256(Array of Base64Organizer, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCreateMeeting.json
+++ b/query/method/message/data/dataCreateMeeting.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256('M'||lao_id||creation||name)"
+			"$comment": "Hash : SHA256(Array of Base64'M', Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCreateMeeting.json
+++ b/query/method/message/data/dataCreateMeeting.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(Array of Base64'M', Base64LAO_id, Base64Creation, Base64Name)"
+			"$comment": "Hash : SHA256(Array of: Base64Encode('M'), Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCreateRollCall.json
+++ b/query/method/message/data/dataCreateRollCall.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256('R'||lao_id||creation||name)"
+			"$comment": "Hash : SHA256(Array of Base64'R', Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataCreateRollCall.json
+++ b/query/method/message/data/dataCreateRollCall.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(Array of Base64'R', Base64LAO_id, Base64Creation, Base64Name)"
+			"$comment": "Hash : SHA256(Array of: Base64Encode('R'), Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataOpenRollCall.json
+++ b/query/method/message/data/dataOpenRollCall.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(Array of Base64'R', Base64LAO_id, Base64Creation, Base64Name)"
+			"$comment": "Hash : SHA256(Array of: Base64Encode('R'), Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"start": {
 			"description": "[Timestamp] start time",

--- a/query/method/message/data/dataOpenRollCall.json
+++ b/query/method/message/data/dataOpenRollCall.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256('R'||lao_id||creation||name)"
+			"$comment": "Hash : SHA256(Array of Base64'R', Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"start": {
 			"description": "[Timestamp] start time",

--- a/query/method/message/data/dataStateLao.json
+++ b/query/method/message/data/dataStateLao.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(Array of Base64Organizer, Base64Creation, Base64Name)"
+			"$comment": "Hash : SHA256(Array of: Base64Organizer, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataStateLao.json
+++ b/query/method/message/data/dataStateLao.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(organizer||creation||name)"
+			"$comment": "Hash : SHA256(Array of Base64Organizer, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },
@@ -53,7 +53,8 @@
 				"additionalProperties": false,
 				"required": ["witness", "signature"]
 			}
-		},
+		}
+	},
 	"additionalProperties": false,
 	"required": ["object", "action", "id", "name", "creation", "last_modified", "organizer", "witnesses", "modification_id", "modification_signatures"],
 	"note": [

--- a/query/method/message/data/dataStateMeeting.json
+++ b/query/method/message/data/dataStateMeeting.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256('M'||lao_id||creation||name)"
+			"$comment": "Hash : SHA256(Array of Base64'M', Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataStateMeeting.json
+++ b/query/method/message/data/dataStateMeeting.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(Array of Base64'M', Base64LAO_id, Base64Creation, Base64Name)"
+			"$comment": "Hash : SHA256(Array of: Base64Encode('M'), Base64LAO_id, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"creation": { "description": "[Timestamp] creation time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataUpdateLao.json
+++ b/query/method/message/data/dataUpdateLao.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(Array of Base64Organizer, Base64Creation, Base64Name)"
+			"$comment": "Hash : SHA256(Array of: Base64Organizer, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"last_modified": { "description": "[Timestamp] last modification's time", "type": "integer", "minimum": 0 },

--- a/query/method/message/data/dataUpdateLao.json
+++ b/query/method/message/data/dataUpdateLao.json
@@ -10,7 +10,7 @@
 		"id": {
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Hash : SHA256(organizer||creation||name)"
+			"$comment": "Hash : SHA256(Array of Base64Organizer, Base64Creation, Base64Name)"
 		},
 		"name": { "type": "string" },
 		"last_modified": { "description": "[Timestamp] last modification's time", "type": "integer", "minimum": 0 },

--- a/query/method/message/messageGeneral.json
+++ b/query/method/message/messageGeneral.json
@@ -25,7 +25,7 @@
 			"$comment": "Note: the string is encoded in Base64"
 		},
 		"message_id": {
-			"description": "[Base64String] message id : Hash(Array of Base64Data, Base64Signature)",
+			"description": "[Base64String] message id : Hash : SHA256(Array of: Base64Data, Base64Signature)",
 			"type": "string",
 			"contentEncoding": "base64",
 			"$comment": "Note: the string is encoded in Base64, the array is written with [\"item1\", \"item2\"] without the backslashs (only used for not breaking json here), and items hashed are their base64 representation to avoid the need of escaping the \" "

--- a/query/method/message/messageGeneral.json
+++ b/query/method/message/messageGeneral.json
@@ -25,11 +25,11 @@
 			"$comment": "Note: the string is encoded in Base64"
 		},
 		"message_id": {
-			"description": "[Base64String] message id : Hash(data||signature)",
+			"description": "[Base64String] message id : Hash(Array of Base64Data, Base64Signature)",
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Note: the string is encoded in Base64"
-		},
+			"$comment": "Note: the string is encoded in Base64, the array is written with [\"item1\", \"item2\"] without the backslashs (only used for not breaking json here), and items hashed are their base64 representation to avoid the need of escaping the \" "
+			},
 		"witness_signatures": {
 			"description": "[Array[Base64String]] signatures of the witnesses on the modification message (either creation/update)",
 			"type": "array",

--- a/query/method/message/messageWitnessMessage.json
+++ b/query/method/message/messageWitnessMessage.json
@@ -25,7 +25,7 @@
 			"$comment": "Note: the string is encoded in Base64"
 		},
 		"message_id": {
-			"description": "[Base64String] message id : Hash(Array of Base64Data, Base64Signature)",
+			"description": "[Base64String] message id : Hash : SHA256(Array of: Base64Data, Base64Signature)",
 			"type": "string",
 			"contentEncoding": "base64",
 			"$comment": "Note: the string is encoded in Base64, the array is written with [\"item1\", \"item2\"] without the backslashs (only used for not breaking json here), and items hashed are their base64 representation to avoid the need of escaping the \" "

--- a/query/method/message/messageWitnessMessage.json
+++ b/query/method/message/messageWitnessMessage.json
@@ -25,10 +25,10 @@
 			"$comment": "Note: the string is encoded in Base64"
 		},
 		"message_id": {
-			"description": "[Base64String] message id : Hash(data||signature)",
+			"description": "[Base64String] message id : Hash(Array of Base64Data, Base64Signature)",
 			"type": "string",
 			"contentEncoding": "base64",
-			"$comment": "Note: the string is encoded in Base64"
+			"$comment": "Note: the string is encoded in Base64, the array is written with [\"item1\", \"item2\"] without the backslashs (only used for not breaking json here), and items hashed are their base64 representation to avoid the need of escaping the \" "
 		},
 		"witness_signatures": {
 			"description": "[Array[Base64String]] list of witnesses' signatures",


### PR DESCRIPTION
**tl;dr**: proposition: hashes should now be made on arrays of base64 encoded strings which look like `["Base64{Foo}", "Base64{Bar}"]` instead of escaping the `"` and `\` within Foo and Bar

---


Hey everyone! 

While performing tests between backend-1 and frontend-1, we stumbled upon an issue that could lead to serious troubles later (possibly next semester). Here's a quick description of the issue:

When hashing the _exact same string_, Go and JavaScript do not yield the same value for very specific cases: escaped characters. We introduced this "bug" in PR #133 when we decided to escape any `"` (quote character) and `\` (backslash character) into `\"` and `\\` respectively.

If either fe1 or be1 decides to adopt the other team's solution, we don't know how fe2 and be2 would react to these changes. Moreover, if be3 is added next semester, those might encounter the exact same problem. Thus, here's our solution to the problem:

Current implementation:
```java
public String hashStrings(Array[String] strs) {
	// transform each string input in base64
	for (String str : strs) { str = escapeString(str); }
	// creates the array in string form
	String arr = ... // result: arr = ["abc", "\"time\":2"]
	// hash the array in string form
	String hashed = hash(arr);

	// return the base64 representation of the hash
	return base64Encode(hashed);
}

// transforms any `"` into `\"` and any `\` into `\\`
public String escapeString(String str) { /* ... */ }
```

Proposed implementation:
```java
public String hashStrings(Array[String] strs) {
	// transform each string input in base64
	for (String str : strs) { str = base64Encode(str); }
	// creates the array in string form
	String arr = ... // result: arr = ["abc=", "bde="]
	// hash the array in string form
	String hashed = hash(arr);

	// return the base64 representation of the hash
	return base64Encode(hashed);
}
```

Note that only the `for-loop` is modified. This way, we will never have to escape characters since every string is encoded in base64.

:information_source: with our solution, **any** string used for hashing is converted in base64 (for-loop). Another solution could be only to encode a subset of those strings. For example, the creation time (`int`) will never contain any problematic characters. The same could be said for `R` and `M` (bytes used for roll-calls and meetings when hashing).

:information_source: frontend-1 is working in a JavaScript environment while backend-1 is working in Go.