### PR TITLE
Fix addTwiceSameAttendeeShowsToast and addTwiceSameWitnessShowsToast tests

### DIFF
--- a/app/src/androidTest/java/com/github/dedis/student20_pop/ui/AddAttendeeFragmentTest.java
+++ b/app/src/androidTest/java/com/github/dedis/student20_pop/ui/AddAttendeeFragmentTest.java
@@ -187,8 +187,8 @@ public class AddAttendeeFragmentTest {
             final String ATTENDEE_ID = "t9Ed+TEwDM0+u0ZLdS4ZB/Vrrnga0Lu2iMkAQtyFRrQ=";
             final String TEST_IDS = ATTENDEE_ID + LAO_ID;
 
-            ((QRCodeScanningFragment) fragment).onQRCodeDetected(TEST_IDS, ADD_ROLL_CALL_ATTENDEE, rollCallEvent.getId());
-
+            rollCallEvent.addAttendee(ATTENDEE_ID);
+            
             List<String> attendees = app.getEvents(app.getCurrentLao()).parallelStream()
                     .filter(event -> event.getId().equals(rollCallEvent.getId()))
                     .map(Event::getAttendees)

--- a/app/src/androidTest/java/com/github/dedis/student20_pop/ui/OrganizerFragmentTest.java
+++ b/app/src/androidTest/java/com/github/dedis/student20_pop/ui/OrganizerFragmentTest.java
@@ -276,6 +276,7 @@ public class OrganizerFragmentTest {
             final String LAO_ID = app.getCurrentLao().getId();
             final String WITNESS_ID = "t9Ed+TEwDM0+u0ZLdS4ZB/Vrrnga0Lu2iMkAQtyFRrQ=";
             final String TEST_IDS = WITNESS_ID + LAO_ID;
+            app.addWitness(WITNESS_ID);
 
             ((QRCodeScanningFragment) fragment).onQRCodeDetected(TEST_IDS, ADD_WITNESS, null);
 
@@ -285,8 +286,6 @@ public class OrganizerFragmentTest {
                     Assert.assertThat(WITNESS_ID, isIn(witnesses));
                 }
             }
-
-            ((QRCodeScanningFragment) fragment).onQRCodeDetected(TEST_IDS, ADD_WITNESS, null);
         });
 
         onView(withText(getApplicationContext().getString(R.string.add_witness_already_exists)))


### PR DESCRIPTION
In the concerned test, two different toasts were shown one after the other and the test were checking that the second one was displayed. Because the first one is still displayed when the check occurs, the tests were failling. This PR fixes that.

