### PR TITLE
Fix Unix Timestamp for Events

### DIFF
--- a/app/src/androidTest/java/com/github/dedis/student20_pop/ui/AddAttendeeFragmentTest.java
+++ b/app/src/androidTest/java/com/github/dedis/student20_pop/ui/AddAttendeeFragmentTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -110,10 +111,8 @@ public class AddAttendeeFragmentTest {
 
             RollCallEvent rollCallEvent = new RollCallEvent(
                     "Random Name",
-                    new Date(),
-                    new Date(),
-                    new Date(),
-                    new Date(),
+                    Instant.now().getEpochSecond(),
+                    Instant.now().getEpochSecond(),
                     LAO_ID,
                     "",
                     "No description",
@@ -172,10 +171,8 @@ public class AddAttendeeFragmentTest {
 
             RollCallEvent rollCallEvent = new RollCallEvent(
                     "Random Name",
-                    new Date(),
-                    new Date(),
-                    new Date(),
-                    new Date(),
+                    Instant.now().getEpochSecond(),
+                    Instant.now().getEpochSecond(),
                     LAO_ID,
                     "",
                     "No description",

--- a/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
@@ -328,9 +328,9 @@ public class PoPApplication extends Application {
     private Map<Lao, List<Event>> dummyLaoEventMap() {
         Map<Lao, List<Event>> map = new HashMap<>();
         List<Event> events = new ArrayList<>();
-        Event event1 = new Event("Future Event 1", new Keys().getPublicKey(), Instant.now().getEpochSecond(), "EPFL", POLL);
+        Event event1 = new Event("Future Event 1", new Keys().getPublicKey(), 2617547969L, "EPFL", POLL);
         Event event2 = new Event("Present Event 1", new Keys().getPublicKey(), Instant.now().getEpochSecond(), "Somewhere", DISCUSSION);
-        Event event3 = new Event("Past Event 1", new Keys().getPublicKey(), Instant.now().getEpochSecond(), "Here", MEETING);
+        Event event3 = new Event("Past Event 1", new Keys().getPublicKey(), 1481643086L, "Here", MEETING);
         events.add(event1);
         events.add(event2);
         events.add(event3);

--- a/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
@@ -40,7 +40,7 @@ public class PoPApplication extends Application {
 
     private static final URI LOCAL_BACKEND_URI = URI.create("ws://10.0.2.2:2000");
 
-    private Map<Lao, List<Event>> laoEventsMap = new HashMap<>(); //final?
+    private final Map<Lao, List<Event>> laoEventsMap = new HashMap<>();
     private final Map<Lao, List<String>> laoWitnessMap = new HashMap<>();
     private final Map<URI, HighLevelProxy> openSessions = new HashMap<>();
 
@@ -99,7 +99,6 @@ public class PoPApplication extends Application {
 
         currentLao = new Lao("LAO I just joined", person.getId());
         dummyLaoEventsMap = dummyLaoEventMap();
-        laoEventsMap = dummyLaoEventsMap;
         laoWitnessMap.put(currentLao, new ArrayList<>());
 
         localProxy = getProxy(LOCAL_BACKEND_URI);

--- a/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
@@ -17,6 +17,7 @@ import com.github.dedis.student20_pop.utility.protocol.ProtocolProxyFactory;
 import com.github.dedis.student20_pop.utility.security.PrivateInfoStorage;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ public class PoPApplication extends Application {
 
     private static final URI LOCAL_BACKEND_URI = URI.create("ws://10.0.2.2:2000");
 
-    private final Map<Lao, List<Event>> laoEventsMap = new HashMap<>();
+    private Map<Lao, List<Event>> laoEventsMap = new HashMap<>(); //final?
     private final Map<Lao, List<String>> laoWitnessMap = new HashMap<>();
     private final Map<URI, HighLevelProxy> openSessions = new HashMap<>();
 
@@ -98,6 +99,7 @@ public class PoPApplication extends Application {
 
         currentLao = new Lao("LAO I just joined", person.getId());
         dummyLaoEventsMap = dummyLaoEventMap();
+        laoEventsMap = dummyLaoEventsMap;
         laoWitnessMap.put(currentLao, new ArrayList<>());
 
         localProxy = getProxy(LOCAL_BACKEND_URI);
@@ -327,9 +329,9 @@ public class PoPApplication extends Application {
     private Map<Lao, List<Event>> dummyLaoEventMap() {
         Map<Lao, List<Event>> map = new HashMap<>();
         List<Event> events = new ArrayList<>();
-        Event event1 = new Event("Future Event 1", new Date(2617547969000L), new Keys().getPublicKey(), "EPFL", POLL);
-        Event event2 = new Event("Present Event 1", new Date(), new Keys().getPublicKey(), "Somewhere", DISCUSSION);
-        Event event3 = new Event("Past Event 1", new Date(1481643086000L), new Keys().getPublicKey(), "Here", MEETING);
+        Event event1 = new Event("Future Event 1", new Keys().getPublicKey(), Instant.now().getEpochSecond(), "EPFL", POLL);
+        Event event2 = new Event("Present Event 1", new Keys().getPublicKey(), Instant.now().getEpochSecond(), "Somewhere", DISCUSSION);
+        Event event3 = new Event("Past Event 1", new Keys().getPublicKey(), Instant.now().getEpochSecond(), "Here", MEETING);
         events.add(event1);
         events.add(event2);
         events.add(event3);

--- a/app/src/main/java/com/github/dedis/student20_pop/model/event/Event.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/event/Event.java
@@ -9,6 +9,7 @@ import com.github.dedis.student20_pop.utility.security.Signature;
 
 import org.json.JSONObject;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -23,6 +24,7 @@ public class Event {
 
     private final String name;
     private final long time;
+    private final long startTime;
     private final String id;
     private final String lao;
     // Can use GeoLocation in the future
@@ -36,17 +38,18 @@ public class Event {
      * Constructor for an Event
      *
      * @param name the name of the event, can be empty
-     * @param time the creation time, can't be modified
      * @param lao  the public key of the associated LAO
+     * @param startTime the event's start time
      * @throws IllegalArgumentException if any of the parameters is null
      */
-    public Event(String name, Date time, String lao, String location, EventType type) {
-        if (name == null || time == null || lao == null || location == null || type == null) {
+    public Event(String name, String lao, long startTime, String location, EventType type) {
+        if (name == null || lao == null || location == null || type == null) {
             throw new IllegalArgumentException("Trying to create an event with null parameters");
         }
         this.name = name;
-        this.time = time.getTime() / 1000L;
-        this.id = Hash.hash(name, time.getTime());
+        this.time = Instant.now().getEpochSecond();
+        this.startTime = startTime;
+        this.id = Hash.hash(name, time);
         this.lao = Hash.hash(lao);
         this.attendees = new ObservableArrayList<>();
         this.location = location;
@@ -59,10 +62,17 @@ public class Event {
     }
 
     /**
-     * @return creation time of the LAO as Unix Timestamp, can't be modified
+     * @return creation time of the event as Unix Timestamp, can't be modified
      */
     public long getTime() {
         return time;
+    }
+
+    /**
+     * @return the start time of the event as Unix Timestamp
+     */
+    public long getStartTime() {
+        return startTime;
     }
 
     /**

--- a/app/src/main/java/com/github/dedis/student20_pop/model/event/MeetingEvent.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/event/MeetingEvent.java
@@ -8,44 +8,23 @@ import static com.github.dedis.student20_pop.model.event.Event.EventType.MEETING
  * Class modelling an Meeting Event
  */
 public class MeetingEvent extends Event {
-    private final Date startDate;
-    private final Date endDate;
-    private final Date startTime;
-    private final Date endTime;
+    private final long endTime;
     private final String description;
 
     /**
      * @param name
-     * @param startDate
-     * @param endDate
      * @param startTime
      * @param endTime
      * @param lao
      * @param location
      */
-    public MeetingEvent(String name, Date startDate, Date endDate, Date startTime, Date endTime, String lao, String location, String description) {
-        super(name, startDate, lao, location, MEETING);
-
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.startTime = startTime;
+    public MeetingEvent(String name, long startTime, long endTime, String lao, String location, String description) {
+        super(name, lao, startTime, location, MEETING);
         this.endTime = endTime;
         this.description = description;
     }
 
-    public Date getStartDate() {
-        return startDate;
-    }
-
-    public Date getEndDate() {
-        return endDate;
-    }
-
-    public Date getStartTime() {
-        return startTime;
-    }
-
-    public Date getEndTime() {
+    public long getEndTime() {
         return endTime;
     }
 

--- a/app/src/main/java/com/github/dedis/student20_pop/model/event/PollEvent.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/event/PollEvent.java
@@ -8,45 +8,27 @@ import java.util.List;
  * Class modelling a poll event
  */
 public final class PollEvent extends Event {
-    private final Date startDate;
-    private final Date endDate;
-    private final Date startTime;
-    private final Date endTime;
+    private final long startTime;
+    private final long endTime;
     private final List<String> choices;
     private final boolean oneOfN;
 
     /**
      * @param question
-     * @param startDate
-     * @param endDate
      * @param startTime
      * @param endTime
      * @param lao
      * @param location
      */
-    public PollEvent(String question, List<String> choices, boolean oneOfN, Date startDate, Date endDate, Date startTime, Date endTime, String lao, String location) {
-        super(question, Calendar.getInstance().getTime(), lao, location, EventType.POLL);
-        this.startDate = startDate;
-        this.endDate = endDate;
+    public PollEvent(String question, List<String> choices, boolean oneOfN, long startTime, long endTime, String lao, String location) {
+        super(question, lao, startTime, location, EventType.POLL);
         this.startTime = startTime;
         this.endTime = endTime;
         this.choices = choices;
         this.oneOfN = oneOfN;
     }
 
-    public Date getStartDate() {
-        return startDate;
-    }
-
-    public Date getEndDate() {
-        return endDate;
-    }
-
-    public Date getStartTime() {
-        return startTime;
-    }
-
-    public Date getEndTime() {
+    public long getEndTime() {
         return endTime;
     }
 

--- a/app/src/main/java/com/github/dedis/student20_pop/model/event/PollEvent.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/event/PollEvent.java
@@ -8,7 +8,6 @@ import java.util.List;
  * Class modelling a poll event
  */
 public final class PollEvent extends Event {
-    private final long startTime;
     private final long endTime;
     private final List<String> choices;
     private final boolean oneOfN;
@@ -22,7 +21,6 @@ public final class PollEvent extends Event {
      */
     public PollEvent(String question, List<String> choices, boolean oneOfN, long startTime, long endTime, String lao, String location) {
         super(question, lao, startTime, location, EventType.POLL);
-        this.startTime = startTime;
         this.endTime = endTime;
         this.choices = choices;
         this.oneOfN = oneOfN;

--- a/app/src/main/java/com/github/dedis/student20_pop/model/event/RollCallEvent.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/event/RollCallEvent.java
@@ -2,7 +2,6 @@ package com.github.dedis.student20_pop.model.event;
 
 import androidx.databinding.ObservableArrayList;
 
-import java.util.Date;
 import java.util.Objects;
 
 import static com.github.dedis.student20_pop.model.event.Event.EventType.ROLL_CALL;
@@ -13,45 +12,26 @@ import static com.github.dedis.student20_pop.model.event.RollCallEvent.AddAttend
  * Class modelling a Roll-Call event
  */
 public final class RollCallEvent extends Event {
-    private final Date startDate;
-    private final Date endDate;
-    private final Date startTime;
-    private final Date endTime;
+    private final long startTime;
+    private final long endTime;
     private final String description;
 
     /**
      * @param name
-     * @param startDate
-     * @param endDate
      * @param startTime
      * @param endTime
      * @param lao
      * @param location
      */
-    public RollCallEvent(String name, Date startDate, Date endDate, Date startTime, Date endTime, String lao, String location, String description, ObservableArrayList<String> attendees) {
-        super(name, startDate, lao, location, ROLL_CALL);
-
-        this.startDate = startDate;
-        this.endDate = endDate;
+    public RollCallEvent(String name, long startTime, long endTime, String lao, String location, String description, ObservableArrayList<String> attendees) {
+        super(name, lao, startTime, location, ROLL_CALL);
         this.startTime = startTime;
         this.endTime = endTime;
         this.description = description;
         this.setAttendees(attendees);
     }
 
-    public Date getStartDate() {
-        return startDate;
-    }
-
-    public Date getEndDate() {
-        return endDate;
-    }
-
-    public Date getStartTime() {
-        return startTime;
-    }
-
-    public Date getEndTime() {
+    public long getEndTime() {
         return endTime;
     }
 

--- a/app/src/main/java/com/github/dedis/student20_pop/model/event/RollCallEvent.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/event/RollCallEvent.java
@@ -12,7 +12,6 @@ import static com.github.dedis.student20_pop.model.event.RollCallEvent.AddAttend
  * Class modelling a Roll-Call event
  */
 public final class RollCallEvent extends Event {
-    private final long startTime;
     private final long endTime;
     private final String description;
 
@@ -25,7 +24,6 @@ public final class RollCallEvent extends Event {
      */
     public RollCallEvent(String name, long startTime, long endTime, String lao, String location, String description, ObservableArrayList<String> attendees) {
         super(name, lao, startTime, location, ROLL_CALL);
-        this.startTime = startTime;
         this.endTime = endTime;
         this.description = description;
         this.setAttendees(attendees);

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/AbstractEventCreationFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/AbstractEventCreationFragment.java
@@ -223,7 +223,7 @@ abstract class AbstractEventCreationFragment extends Fragment {
             startDate = Calendar.getInstance();
         }
         if (startTime == null){
-            startDate = Calendar.getInstance();
+            startTime = Calendar.getInstance();
         }
         completeStartTime.set(startDate.get(Calendar.YEAR),
                 startDate.get(Calendar.MONTH),

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/MeetingEventCreationFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/MeetingEventCreationFragment.java
@@ -83,12 +83,12 @@ public final class MeetingEventCreationFragment extends AbstractEventCreationFra
         confirmButton = view.findViewById(R.id.meeting_event_creation_confirm);
         confirmButton.setOnClickListener(v -> {
 
+            computeTimesInSeconds();
+
             Event meetingEvent = new MeetingEvent(
                     meetingTitleEditText.getText().toString(),
-                    startDate,
-                    endDate,
-                    startTime,
-                    endTime,
+                    startTimeInSeconds,
+                    endTimeInSeconds,
                     app.getCurrentLao().getId(),
                     meetingLocationEditText.getText().toString(),
                     meetingDescriptionEditText.getText().toString());
@@ -104,10 +104,5 @@ public final class MeetingEventCreationFragment extends AbstractEventCreationFra
         });
 
         return view;
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        checkDates(requestCode, resultCode, data);
     }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/PollEventCreationFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/PollEventCreationFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.student20_pop.ui.event.creation;
 
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -135,13 +134,12 @@ public final class PollEventCreationFragment extends AbstractEventCreationFragme
             PoPApplication app = (PoPApplication) (getActivity().getApplication());
             String question = questionEditText.getText().toString();
             List<String> choicesList = getChoices(choicesListView);
+            computeTimesInSeconds();
             Event pollEvent = new PollEvent(question,
                     choicesList,
                     pollTypeIsOneOfN,
-                    startDate,
-                    endDate,
-                    startTime,
-                    endTime,
+                    startTimeInSeconds,
+                    endTimeInSeconds,
                     app.getCurrentLao().getId(),
                     NO_LOCATION);
             eventCreatedListener.OnEventCreatedListener(pollEvent);
@@ -154,11 +152,6 @@ public final class PollEventCreationFragment extends AbstractEventCreationFragme
             fragmentManager.popBackStackImmediate();
         });
         return view;
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        checkDates(requestCode, resultCode, data);
     }
 
     private boolean isScheduleButtonEnabled() {

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/RollCallEventCreationFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/RollCallEventCreationFragment.java
@@ -82,13 +82,14 @@ public final class RollCallEventCreationFragment extends AbstractEventCreationFr
 
         confirmButton = view.findViewById(R.id.roll_call_confirm);
         confirmButton.setOnClickListener(v -> {
+
+            computeTimesInSeconds();
+
             if (rollCallEvent == null) {
                 rollCallEvent = new RollCallEvent(
                         rollCallTitleEditText.getText().toString(),
-                        startDate,
-                        endDate,
-                        startTime,
-                        endTime,
+                        startTimeInSeconds,
+                        endTimeInSeconds,
                         app.getCurrentLao().getId(),
                         NO_LOCATION,
                         rollCallDescriptionEditText.getText().toString(),
@@ -100,12 +101,13 @@ public final class RollCallEventCreationFragment extends AbstractEventCreationFr
         });
 
         openButton.setOnClickListener(v -> {
+
+            computeTimesInSeconds();
+
             rollCallEvent = new RollCallEvent(
                     rollCallTitleEditText.getText().toString(),
-                    startDate,
-                    endDate,
-                    startTime,
-                    endTime,
+                    startTimeInSeconds,
+                    endTimeInSeconds,
                     app.getCurrentLao().getId(),
                     NO_LOCATION,
                     rollCallDescriptionEditText.getText().toString(),
@@ -121,10 +123,5 @@ public final class RollCallEventCreationFragment extends AbstractEventCreationFr
         });
 
         return view;
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        checkDates(requestCode, resultCode, data);
     }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/pickers/DatePickerFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/pickers/DatePickerFragment.java
@@ -42,7 +42,6 @@ public final class DatePickerFragment extends AppCompatDialogFragment implements
         calendar.set(Calendar.YEAR, year);
         calendar.set(Calendar.MONTH, month);
         calendar.set(Calendar.DAY_OF_MONTH, day);
-        String selectedDate = DATE_FORMAT.format(calendar.getTime());
 
         // send date back to the target fragment
         getTargetFragment().onActivityResult(

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/pickers/DatePickerFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/pickers/DatePickerFragment.java
@@ -48,7 +48,7 @@ public final class DatePickerFragment extends AppCompatDialogFragment implements
         getTargetFragment().onActivityResult(
                 getTargetRequestCode(),
                 Activity.RESULT_OK,
-                new Intent().putExtra(getString(R.string.picker_selection), selectedDate)
+                new Intent().putExtra(getString(R.string.picker_selection), calendar)
         );
     }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/pickers/TimePickerFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/pickers/TimePickerFragment.java
@@ -42,8 +42,6 @@ public final class TimePickerFragment extends AppCompatDialogFragment implements
         calendar.set(Calendar.HOUR_OF_DAY, hourOfDay);
         calendar.set(Calendar.MINUTE, minute);
 
-        String selectedTime = TIME_FORMAT.format(calendar.getTime());
-
         getTargetFragment().onActivityResult(
                 getTargetRequestCode(),
                 Activity.RESULT_OK,

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/pickers/TimePickerFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/event/creation/pickers/TimePickerFragment.java
@@ -38,6 +38,7 @@ public final class TimePickerFragment extends AppCompatDialogFragment implements
      */
     @Override
     public void onTimeSet(TimePicker view, int hourOfDay, int minute) {
+        calendar.setTimeInMillis(0L);
         calendar.set(Calendar.HOUR_OF_DAY, hourOfDay);
         calendar.set(Calendar.MINUTE, minute);
 
@@ -46,7 +47,7 @@ public final class TimePickerFragment extends AppCompatDialogFragment implements
         getTargetFragment().onActivityResult(
                 getTargetRequestCode(),
                 Activity.RESULT_OK,
-                new Intent().putExtra(getString(R.string.picker_selection), selectedTime)
+                new Intent().putExtra(getString(R.string.picker_selection), calendar)
         );
     }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/ui/eventadapter/ExpandableListViewEventAdapter.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/ui/eventadapter/ExpandableListViewEventAdapter.java
@@ -9,9 +9,12 @@ import android.widget.TextView;
 
 import com.github.dedis.student20_pop.R;
 import com.github.dedis.student20_pop.model.event.Event;
+import com.github.dedis.student20_pop.model.event.RollCallEvent;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -185,8 +188,8 @@ public abstract class ExpandableListViewEventAdapter extends BaseExpandableListA
         // in the future it could be nice to have a pencil icon to allow organizer to modify an event
         Event event = ((Event) getChild(groupPosition, childPosition));
         String eventTitle = (event.getName() + " : " + event.getType());
-        String eventDescription = "Time : " + event.getTime() + "\nLocation : " + event.getLocation();
-
+        String eventDescription = "";
+        String time = DATE_FORMAT.format(event.getStartTime()*1000L);
         if (convertView == null) {
             LayoutInflater inflater = (LayoutInflater) this.context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             convertView = inflater.inflate(R.layout.layout_event, null);
@@ -196,9 +199,10 @@ public abstract class ExpandableListViewEventAdapter extends BaseExpandableListA
         eventTitleTextView.setText(eventTitle);
         switch (event.getType()) {
             case ROLL_CALL:
-                eventDescription += ("\nParticipants: " + event.getAttendees().size());
+                eventDescription = "Start Time : " + time + "\nLocation : " + event.getLocation() + "\nParticipants: " + event.getAttendees().size();
                 break;
             default:
+                eventDescription = "Start Time : " + time + "\nLocation : " + event.getLocation();
                 break;
         }
         descriptionTextView.setText(eventDescription);
@@ -219,11 +223,11 @@ public abstract class ExpandableListViewEventAdapter extends BaseExpandableListA
         for (Event event : events) {
             //for now (testing purposes)
             //later: event.getEndTime() < now
-            if (event.getTime() < (System.currentTimeMillis() / 1000L)) {
+            if (event.getTime() < (Instant.now().getEpochSecond())) {
                 eventsMap.get(PAST).add(event);
             }
             //later: event.getStartTime()<now && event.getEndTime() > now
-            else if (event.getTime() <= System.currentTimeMillis() / 1000L) {
+            else if (event.getTime() <= Instant.now().getEpochSecond()) {
                 eventsMap.get(PRESENT).add(event);
             } else { //if e.getStartTime() > now
                 eventsMap.get(FUTURE).add(event);

--- a/app/src/test/java/com/github/dedis/student20_pop/model/EventsTest.java
+++ b/app/src/test/java/com/github/dedis/student20_pop/model/EventsTest.java
@@ -9,6 +9,7 @@ import com.github.dedis.student20_pop.utility.security.Signature;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,22 +25,21 @@ public class EventsTest {
 
     private final String name1 = new Keys().getPublicKey();
     private final String name2 = new Keys().getPublicKey();
-    private final Date time = (new Date());
+    private final long time = Instant.now().getEpochSecond();
     private final String lao = new Keys().getPublicKey();
     private final String location = "EPFL";
     private final Event.EventType type = Event.EventType.ROLL_CALL;
     private final ObservableArrayList<String> attendees = new ObservableArrayList<>();
     private final ObservableArrayList<String> attendeesWithNull = new ObservableArrayList<>();
-    private final Event event1 = new Event(name1, time, lao, location, type);
-    private final Event event2 = new Event(name2, time, lao, location, type);
+    private final Event event1 = new Event(name1, lao, time, location, type);
+    private final Event event2 = new Event(name2, lao, time, location, type);
 
     @Test
     public void createEventWithNullParametersTest() {
-        assertThrows(IllegalArgumentException.class, () -> new Event(null, time, lao, location, type));
-        assertThrows(IllegalArgumentException.class, () -> new Event(name1, null, lao, location, type));
-        assertThrows(IllegalArgumentException.class, () -> new Event(name1, time, null, location, type));
-        assertThrows(IllegalArgumentException.class, () -> new Event(name1, time, lao, null, type));
-        assertThrows(IllegalArgumentException.class, () -> new Event(name1, time, lao, location, null));
+        assertThrows(IllegalArgumentException.class, () -> new Event(null, lao, time, location, type));
+        assertThrows(IllegalArgumentException.class, () -> new Event(name1, null, time, location, type));
+        assertThrows(IllegalArgumentException.class, () -> new Event(name1, lao, time, null, type));
+        assertThrows(IllegalArgumentException.class, () -> new Event(name1, lao, time, location, null));
     }
 
     @Test
@@ -49,12 +49,12 @@ public class EventsTest {
 
     @Test
     public void getTimeTest() {
-        assertThat(event1.getTime(), is(time.getTime() / 1000L));
+        assertThat(event1.getStartTime(), is(time));
     }
 
     @Test
     public void getIdTest() {
-        assertThat(event1.getId(), is(Hash.hash(name1, time.getTime())));
+        assertThat(event1.getId(), is(Hash.hash(name1, event1.getTime())));
     }
 
     @Test


### PR DESCRIPTION
- Remove all objects of type Date, use Calendar and Instant instead
- Events have an automatic creation time (used for the id)
- Events take a "long startTime" as parameter, startTime in seconds
- the startTime is displayed for the events (instead of creation time)
