### PR TITLE
Add Swipe-to-Refresh

### DIFF
--- a/app/src/androidTest/java/com/github/dedis/student20_pop/ui/AddAttendeeFragmentTest.java
+++ b/app/src/androidTest/java/com/github/dedis/student20_pop/ui/AddAttendeeFragmentTest.java
@@ -114,9 +114,10 @@ public class AddAttendeeFragmentTest {
                     Instant.now().getEpochSecond(),
                     Instant.now().getEpochSecond(),
                     LAO_ID,
+                    new ObservableArrayList<>(),
                     "",
-                    "No description",
-                    new ObservableArrayList<>()
+                    "No description"
+
             );
 
             app.addEvent(rollCallEvent);
@@ -174,9 +175,9 @@ public class AddAttendeeFragmentTest {
                     Instant.now().getEpochSecond(),
                     Instant.now().getEpochSecond(),
                     LAO_ID,
+                    new ObservableArrayList<>(),
                     "",
-                    "No description",
-                    new ObservableArrayList<>()
+                    "No description"
             );
 
             app.addEvent(rollCallEvent);

--- a/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
@@ -97,8 +97,7 @@ public class PoPApplication extends Application {
             }
         }
 
-        currentLao = new Lao("LAO I just joined", person.getId());
-        dummyLaoEventsMap = dummyLaoEventMap();
+        //activateTestingValues(); //uncomment this line when testing without a back-end
         laoWitnessMap.put(currentLao, new ArrayList<>());
 
         localProxy = getProxy(LOCAL_BACKEND_URI);
@@ -251,6 +250,17 @@ public class PoPApplication extends Application {
     }
 
     /**
+     * @param lao to modify
+     * @param newLao the modified lao
+     */
+    public void modifyLao(Lao lao, Lao newLao){
+        List<Event> events = laoEventsMap.remove(lao);
+        if (events != null){
+            laoEventsMap.put(newLao, events);
+        }
+    }
+
+    /**
      * @param event to be added to the current lao
      */
     public void addEvent(Event event) {
@@ -325,8 +335,7 @@ public class PoPApplication extends Application {
      *
      * @return the dummy map
      */
-    private Map<Lao, List<Event>> dummyLaoEventMap() {
-        Map<Lao, List<Event>> map = new HashMap<>();
+    private void dummyLaoEventMap() {
         List<Event> events = new ArrayList<>();
         Event event1 = new Event("Future Event 1", new Keys().getPublicKey(), 2617547969L, "EPFL", POLL);
         Event event2 = new Event("Present Event 1", new Keys().getPublicKey(), Instant.now().getEpochSecond(), "Somewhere", DISCUSSION);
@@ -337,12 +346,19 @@ public class PoPApplication extends Application {
 
         String notMyPublicKey = new Keys().getPublicKey();
 
-        map.put(currentLao, events);
-        map.put(new Lao("LAO 1", notMyPublicKey), events);
-        map.put(new Lao("LAO 2", notMyPublicKey), events);
-        map.put(new Lao("My LAO 3", person.getId()), events);
-        map.put(new Lao("LAO 4", notMyPublicKey), events);
-        return map;
+        laoEventsMap.put(currentLao, events);
+        laoEventsMap.put(new Lao("LAO 1", notMyPublicKey), events);
+        laoEventsMap.put(new Lao("LAO 2", notMyPublicKey), events);
+        laoEventsMap.put(new Lao("My LAO 3", person.getId()), events);
+        laoEventsMap.put(new Lao("LAO 4", notMyPublicKey), events);
+    }
+
+    /**
+     * Only useful when testing without a back-end
+     */
+    public void activateTestingValues(){
+        currentLao = new Lao("LAO I just joined", person.getId());
+        dummyLaoEventMap();
     }
 
     /**

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/AttendeeFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/AttendeeFragment.java
@@ -14,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.fragment.app.Fragment;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.github.dedis.student20_pop.PoPApplication;
 import com.github.dedis.student20_pop.R;
@@ -57,11 +58,12 @@ public class AttendeeFragment extends Fragment {
         //Display Properties
         View propertiesView = rootView.findViewById(R.id.properties_view);
         ((TextView) propertiesView.findViewById(R.id.organization_name)).setText(lao.getName());
+        SwipeRefreshLayout swipeRefreshLayout = rootView.findViewById(R.id.swipe_refresh);
 
-        final WitnessListViewAdapter adapter = new WitnessListViewAdapter(getActivity(), (ArrayList<String>) app.getWitnesses(lao));
+        final WitnessListViewAdapter witnessListViewAdapter = new WitnessListViewAdapter(getActivity(), (ArrayList<String>) app.getWitnesses(lao));
 
         witnessesListView = propertiesView.findViewById(R.id.witness_list);
-        witnessesListView.setAdapter(adapter);
+        witnessesListView.setAdapter(witnessListViewAdapter);
         propertiesButton = rootView.findViewById(R.id.tab_properties);
 
         propertiesButton.setOnClickListener(clicked -> {
@@ -70,6 +72,19 @@ public class AttendeeFragment extends Fragment {
             } else {
                 propertiesView.setVisibility(View.GONE);
             }
+        });
+
+        swipeRefreshLayout.setOnRefreshListener(() -> {
+            witnessListViewAdapter.notifyDataSetChanged();
+            listViewEventAdapter.notifyDataSetChanged();
+            if (getFragmentManager() != null) {
+                getFragmentManager()
+                        .beginTransaction()
+                        .detach(this)
+                        .attach(this)
+                        .commit();
+            }
+            swipeRefreshLayout.setRefreshing(false);
         });
 
         return rootView;

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/HomeFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/HomeFragment.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.github.dedis.student20_pop.AttendeeActivity;
 import com.github.dedis.student20_pop.OrganizerActivity;
@@ -47,6 +48,7 @@ public final class HomeFragment extends Fragment {
         laos = app.getLaos();
         LinearLayout welcome = view.findViewById(R.id.welcome_screen);
         LinearLayout list = view.findViewById(R.id.list_screen);
+        SwipeRefreshLayout swipeRefreshLayout = view.findViewById(R.id.swipe_refresh);
 
         if (laos.isEmpty()) {
             welcome.setVisibility(View.VISIBLE);
@@ -56,7 +58,19 @@ public final class HomeFragment extends Fragment {
             list.setVisibility(View.VISIBLE);
         }
         ListView laosListView = view.findViewById(R.id.lao_list);
-        laosListView.setAdapter(new LaoListAdapter(this.getContext()));
+        LaoListAdapter adapter = new LaoListAdapter(this.getContext(), laos);
+        laosListView.setAdapter(adapter);
+        swipeRefreshLayout.setOnRefreshListener(() -> {
+            adapter.notifyDataSetChanged();
+            if (getFragmentManager() != null) {
+                getFragmentManager()
+                        .beginTransaction()
+                        .detach(this)
+                        .attach(this)
+                        .commit();
+            }
+            swipeRefreshLayout.setRefreshing(false);
+        });
         return view;
     }
 
@@ -65,19 +79,21 @@ public final class HomeFragment extends Fragment {
      */
     private class LaoListAdapter extends BaseAdapter {
         private final Context context;
+        private List<Lao> laoList;
 
-        public LaoListAdapter(Context context) {
+        public LaoListAdapter(Context context, List<Lao> laos) {
             this.context = context;
+            this.laoList = laos;
         }
 
         @Override
         public int getCount() {
-            return laos.size();
+            return laoList.size();
         }
 
         @Override
         public Object getItem(int position) {
-            return laos.get(position);
+            return laoList.get(position);
         }
 
         @Override
@@ -92,7 +108,7 @@ public final class HomeFragment extends Fragment {
                 LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
                 convertView = inflater.inflate(R.layout.layout_lao_home, null);
             }
-            Lao lao = laos.get(position);
+            Lao lao = laoList.get(position);
             ((TextView) convertView.findViewById(R.id.lao_name)).setText(lao.getName());
             ((TextView) convertView.findViewById(R.id.date)).setText(DATE_FORMAT.format(lao.getTime()*1000L));
             boolean isOrganizer = (lao.getOrganizer()).equals(id);

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/OrganizerFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/OrganizerFragment.java
@@ -17,6 +17,7 @@ import android.widget.ViewSwitcher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.github.dedis.student20_pop.PoPApplication;
 import com.github.dedis.student20_pop.R;
@@ -71,15 +72,17 @@ public class OrganizerFragment extends Fragment {
 
         List<Event> events = app.getEvents(lao);
 
+        SwipeRefreshLayout swipeRefreshLayout = rootView.findViewById(R.id.swipe_refresh);
+
         //Layout Properties fields
         ViewSwitcher viewSwitcher = rootView.findViewById(R.id.viewSwitcher);
         View propertiesView = rootView.findViewById(R.id.properties_view);
         laoNameTextView = propertiesView.findViewById(R.id.organization_name);
         laoNameTextView.setText(lao.getName());
 
-        final WitnessListViewAdapter adapter = new WitnessListViewAdapter(getActivity(), (ArrayList<String>) app.getWitnesses(lao));
+        final WitnessListViewAdapter witnessListViewAdapter = new WitnessListViewAdapter(getActivity(), (ArrayList<String>) app.getWitnesses(lao));
         ListView witnessesListView = propertiesView.findViewById(R.id.witness_list);
-        witnessesListView.setAdapter(adapter);
+        witnessesListView.setAdapter(witnessListViewAdapter);
 
         editPropertiesButton = rootView.findViewById(R.id.edit_button);
         editPropertiesButton
@@ -93,7 +96,7 @@ public class OrganizerFragment extends Fragment {
         laoNameEditText = propertiesEditView.findViewById(R.id.organization_name_editText);
         laoNameEditText.setText(lao.getName());
         ListView witnessesEditListView = propertiesEditView.findViewById(R.id.witness_edit_list);
-        witnessesEditListView.setAdapter(adapter);
+        witnessesEditListView.setAdapter(witnessListViewAdapter);
 
         addWitnessButton = propertiesEditView.findViewById(R.id.add_witness_button);
         Button confirmButton = propertiesEditView.findViewById(R.id.properties_edit_confirm);
@@ -153,6 +156,19 @@ public class OrganizerFragment extends Fragment {
                     }
                 }
         );
+
+        swipeRefreshLayout.setOnRefreshListener(() -> {
+            witnessListViewAdapter.notifyDataSetChanged();
+            listViewEventAdapter.notifyDataSetChanged();
+            if (getFragmentManager() != null) {
+                getFragmentManager()
+                        .beginTransaction()
+                        .detach(this)
+                        .attach(this)
+                        .commit();
+            }
+            swipeRefreshLayout.setRefreshing(false);
+        });
 
         return rootView;
     }

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/ui/adapter/EventExpandableListViewAdapter.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/ui/adapter/EventExpandableListViewAdapter.java
@@ -14,6 +14,7 @@ import com.github.dedis.student20_pop.model.event.EventCategory;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -216,17 +217,16 @@ public abstract class EventExpandableListViewAdapter extends BaseExpandableListA
      * @param eventsMap
      */
     private void putEventsInMap(List<Event> events, HashMap<EventCategory, List<Event>> eventsMap) {
-        //TODO: make the difference clear between PAST and PRESENT
-        //For now, the event are put in the different categories according to their time attribute
-        //Later, according to the start/end-time
         for (Event event : events) {
-            //for now (testing purposes)
+            Calendar calendar = Calendar.getInstance();
+            calendar.add(Calendar.DATE, -1);
+            long yesterday = (Instant.ofEpochMilli(calendar.getTimeInMillis())).getEpochSecond();
             //later: event.getEndTime() < now
-            if (event.getTime() < (Instant.now().getEpochSecond())) {
+            if (event.getStartTime() < yesterday){
                 eventsMap.get(PAST).add(event);
             }
             //later: event.getStartTime()<now && event.getEndTime() > now
-            else if (event.getTime() <= Instant.now().getEpochSecond()) {
+            else if (event.getStartTime() <= Instant.now().getEpochSecond()) {
                 eventsMap.get(PRESENT).add(event);
             } else { //if e.getStartTime() > now
                 eventsMap.get(FUTURE).add(event);

--- a/app/src/main/res/layout/fragment_attendee.xml
+++ b/app/src/main/res/layout/fragment_attendee.xml
@@ -32,11 +32,17 @@
             layout="@layout/layout_properties"
             android:visibility="gone" />
 
-        <ExpandableListView
-            android:id="@+id/exp_list_view"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layoutDirection="ltr" />
+            android:layout_height="wrap_content"
+            android:id="@+id/swipe_refresh" >
+
+            <ExpandableListView
+                android:id="@+id/exp_list_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layoutDirection="ltr" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -57,14 +57,19 @@
         android:visibility="gone"
         app:layout_constraintTop_toTopOf="@id/guideline_horizontal_tab">
 
-        <ListView
-            android:id="@+id/lao_list"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginLeft="@dimen/margin_button"
-            android:layout_marginRight="@dimen/margin_button"
-            android:divider="@color/white"
-            android:dividerHeight="@dimen/margin_top" />
+            android:layout_height="wrap_content"
+            android:id="@+id/swipe_refresh" >
+            <ListView
+                android:id="@+id/lao_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginLeft="@dimen/margin_button"
+                android:layout_marginRight="@dimen/margin_button"
+                android:divider="@color/white"
+                android:dividerHeight="@dimen/margin_top" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_organizer.xml
+++ b/app/src/main/res/layout/fragment_organizer.xml
@@ -52,12 +52,17 @@
                 layout="@layout/layout_properties_edit" />
         </ViewSwitcher>
 
-
-        <ExpandableListView
-            android:id="@+id/organizer_expandable_list_view"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layoutDirection="ltr" />
+            android:layout_height="wrap_content"
+            android:id="@+id/swipe_refresh" >
+
+            <ExpandableListView
+                android:id="@+id/organizer_expandable_list_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layoutDirection="ltr" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,9 @@
     <string name="end_time_before_start_time_not_allowed">End time must be after start time</string>
     <string name="end_time_optional">End Time</string>
     <string name="picker_selection">selection</string>
+    <string name="past_events">Past Events</string>
+    <string name="present_events">Present Events</string>
+    <string name="future_events">Future Events</string>
 
     <!-- Meeting Event -->
     <string name="meeting_event">Meeting Event</string>


### PR DESCRIPTION
- add swipe-to-refresh in Attendee, Organizer and Home UIs so they can be updated when a LAO or event is added/removed/modified
- create modifyLao in PoPApplication
- create a method that populates the data that we can uncomment when testing without a back-end (useful for testing the UI) (the dummy data was already there, it just makes it more clear)
- it's a detail but now, there is a clear distinction between past and present events, and their category (past, present, future) depends on their start times, not creation times
- fix bugs (AddAttendeeFragmentTest was broken)