### PR TITLE
Fix signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The project relies on several sbt dependencies (external libraries) :
 - websockets : [**akka-http**](https://doc.akka.io/docs/akka-http/current/introduction.html) for websocket server. It uses [akka-streams](https://doc.akka.io/docs/akka/current/stream/index.html) as dependency.
 - database : [**leveldb**](https://github.com/codeborui/leveldb-scala) which relies on both [snappy](https://search.maven.org/artifact/org.xerial.snappy/snappy-java/1.1.7.3/jar) (for compression/decompression) and [akka-persistence](https://doc.akka.io/docs/akka/current/persistence.html)
 - Json parser : [**spray-json**](https://github.com/spray/spray-json) for Json encoding/decoding
-- encryption : [**scrypto**](https://index.scala-lang.org/input-output-hk/scrypto/scrypto/2.1.9?target=_2.13) to verify signatures
+- encryption : [**tink**](https://github.com/google/tink/blob/master/docs/JAVA-HOWTO.md) to verify signatures
 - testing : [**scalatest**](https://www.scalatest.org/) for unit tests
 
 ---

--- a/build.sbt
+++ b/build.sbt
@@ -29,9 +29,10 @@ libraryDependencies += "org.xerial.snappy" % "snappy-java" % "1.1.7.3"
 libraryDependencies += "io.spray" %%  "spray-json" % "1.3.5"
 
 //Encryption
-libraryDependencies += "org.scorexfoundation" %% "scrypto" % "2.1.9"
+libraryDependencies += "com.google.crypto.tink" % "tink" % "1.5.0"
 
 // Scala unit tests
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % Test
+
 
 conflictManager := ConflictManager.latestCompatible

--- a/src/main/scala/ch/epfl/pop/Server.scala
+++ b/src/main/scala/ch/epfl/pop/Server.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.TimeUnit
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.stream.scaladsl.{BroadcastHub, Keep, MergeHub}
 import akka.util.Timeout
@@ -24,7 +23,7 @@ object Server {
    */
   def main(args: Array[String]): Unit = {
     val PORT = 8000
-    val PATH = "pop"
+    val PATH = ""
 
     val root = Behaviors.setup[Nothing] { context =>
       implicit val system: ActorSystem[Nothing] = context.system

--- a/src/main/scala/ch/epfl/pop/crypto/Signature.scala
+++ b/src/main/scala/ch/epfl/pop/crypto/Signature.scala
@@ -1,11 +1,11 @@
 package ch.epfl.pop.crypto
 
-import java.nio.charset.StandardCharsets
-
 import ch.epfl.pop.json.{Base64String, Key, Signature}
-import scorex.crypto.signatures
-import scorex.crypto.signatures.Curve25519
-import scorex.util.encode.Base16
+import com.google.crypto.tink.subtle.Ed25519Verify
+
+import java.security.GeneralSecurityException
+import java.util.Base64
+import java.nio.charset.StandardCharsets.UTF_8
 
 object Signature {
 
@@ -18,9 +18,15 @@ object Signature {
    * @return whether the signature is correct
    */
   def verify(msg: Base64String, signature: Signature, key: Key): Boolean = {
-    val sigTagged = signatures.Signature @@ signature
-    val keyTagged = signatures.PublicKey @@ key
+    val ed = new Ed25519Verify(key)
+    val msgDecoded = Base64.getDecoder.decode(msg.getBytes(UTF_8))
 
-    Curve25519.verify(sigTagged, msg.getBytes(StandardCharsets.UTF_8), keyTagged)
+    try {
+      ed.verify(signature, msgDecoded)
+      true
+    }
+    catch {
+      case _ : GeneralSecurityException => false
+    }
   }
 }

--- a/src/main/scala/ch/epfl/pop/json/JsonCommunicationProtocol.scala
+++ b/src/main/scala/ch/epfl/pop/json/JsonCommunicationProtocol.scala
@@ -7,6 +7,7 @@ import ch.epfl.pop.json.Methods.Methods
 import ch.epfl.pop.json.Objects.Objects
 import spray.json._
 
+import java.nio.charset.StandardCharsets
 import scala.collection.immutable
 import scala.util.{Failure, Success, Try}
 
@@ -49,7 +50,8 @@ object JsonCommunicationProtocol extends DefaultJsonProtocol {
   /* implicit used to parse/serialize a String encoded in Base64 */
   implicit object ByteArrayFormat extends RootJsonFormat[ByteArray] {
     @throws(classOf[IllegalArgumentException])
-    override def read(json: JsValue): ByteArray = JsonUtils.DECODER.decode(json.convertTo[String])
+    override def read(json: JsValue): ByteArray =
+      JsonUtils.DECODER.decode(json.convertTo[String].getBytes(StandardCharsets.UTF_8))
     override def write(obj: ByteArray): JsValue = JsString(JsonUtils.ENCODER.encode(obj).map(_.toChar).mkString)
   }
 

--- a/src/test/scala/ch/epfl/pop/tests/crypto/HashTest.scala
+++ b/src/test/scala/ch/epfl/pop/tests/crypto/HashTest.scala
@@ -4,7 +4,6 @@ import java.math.BigInteger
 import java.util.Arrays
 import ch.epfl.pop.crypto.Hash
 import org.scalatest.FunSuite
-import scorex.crypto.signatures.{Curve25519, PublicKey}
 
 import java.nio.charset.StandardCharsets
 

--- a/src/test/scala/ch/epfl/pop/tests/crypto/SignatureTest.scala
+++ b/src/test/scala/ch/epfl/pop/tests/crypto/SignatureTest.scala
@@ -1,29 +1,27 @@
 package ch.epfl.pop.tests.crypto
 
-import java.nio.charset.StandardCharsets
-
 import ch.epfl.pop.crypto.Signature
+import ch.epfl.pop.tests.MessageCreationUtils.{b64EncodeToString, generateKeyPair, sign}
 import org.scalatest.FunSuite
-import scorex.crypto.signatures.Curve25519
+import java.nio.charset.StandardCharsets.UTF_8
 
 class SignatureTest extends FunSuite {
 
   test("Verify correct signature") {
-    val seed = "PoP".getBytes
     val msg = "{\"ts\": 1604911874, \"type\":\"rollcall\"}"
-    val (sk, pk) = Curve25519.createKeyPair(seed)
-    val sig = Curve25519.sign(sk, msg.getBytes(StandardCharsets.UTF_8))
+    val kp = generateKeyPair()
+    val sig = sign(kp, msg.getBytes(UTF_8))
 
-    assert(Signature.verify(msg, sig, pk))
+    val msgEncoded = b64EncodeToString(msg.getBytes(UTF_8))
+    assert(Signature.verify(msgEncoded, sig, kp.getPublicKey))
   }
 
   test("Signature verification fails on incorrect signature") {
-    val seed = "PoP".getBytes
     val msg = "{\"ts\": 1604911874, \"type\":\"rollcall\"}"
-    val (_, pk) = Curve25519.createKeyPair(seed)
+    val pk = generateKeyPair().getPublicKey
     val sig = "incorrect signature".getBytes()
 
-    assert(!Signature.verify(msg, sig, pk))
+    val msgEncoded = b64EncodeToString(msg.getBytes(UTF_8))
+    assert(!Signature.verify(msgEncoded, sig, pk))
   }
-
 }


### PR DESCRIPTION
Make signatures compatible with the version of other teams.
- Add a missing check on message signature when creating a LAO
- Compute signature on messages before encoding them to base64 (to be consistent with other teams)
- Fix an encoding issue where UTF-8 was not used
- Change the cryptography library to tink, as the library we used seems to not be compatible with cryptography libraries of other teams
- Update unit tests accordingly (most of line change)